### PR TITLE
Logical parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@
        * [11. Editing a Matrix](#11-editing-a-matrix)
           * [Editing a Matrix example](#editing-a-matrix-example)
        * [12. Finding the characteristic polynomial of a Matrix](#12-finding-the-characteristic-polynomial-of-a-matrix)
- * [TO BE CONTINUED](#to-be-continued)
+* [Logical Calculus](#logical-calculus)
+* [TO BE CONTINUED](#to-be-continued)
 
 
 ## Usage and note
@@ -47,7 +48,7 @@ If you need to access this library via Maven Central, do:
         <dependency>
             <groupId>com.github.gbenroscience</groupId>
             <artifactId>parser-ng</artifactId>
-            <version>0.1.7</version>
+            <version>0.1.8</version>
         </dependency>
        
 
@@ -79,21 +80,31 @@ ParserNG is written completely in (pure) Java and so is as cross-platform as Jav
 </ol>
 
 ## Using ParserNG as commandline tool
-You cn use jar dirrectly as commandline calculus. Unless the tool is packed to your distribution:
+You can use jar directly as commandline calculus. Unless the tool is packed to your distribution:
 ```
-java -jar parser-ng-0.1.7.jar  1+1
+java -jar parser-ng-0.1.8.jar  1+1
 2.0
+```
+Or as logical parser
+```
+java -jar parser-ng-0.1.8.jar -l true and true
+true
+java -jar parser-ng-0.1.8.jar -l "2 == (4-2)"
+true
 ```
 You can get help by 
 ```
-java -jar parser-ng-0.1.7.jar  -h
-  ParserNG 0.1.7 math.Main
+java -jar parser-ng-0.1.8.jar  -h
+  ParserNG 0.1.8 math.Main
 -h/-H/--help         this text; do not change for help (witout dashes), which lists functions
 -v/-V/--verbose      output is reprinted to stderr with some inter-steps
+-l/-L/--logic        will add logical expression wrapper around the expression
+                     Logical expression parser is much less evolved and slow. Do not use it if you don't must
+                     If you use logical parse, result is always true/false. If it is not understood, it reuslts to false
 -t/-T/--trim         by default, each line is one expression,
                      however for better redability, sometimes it is worthy to
                      to split the expression to multiple lines. and evaluate as one.
--i/-I/--interaktive  instead of evaluating any input, interactive prompt is opened
+-i/-I/--interactive  instead of evaluating any input, interactive prompt is opened
                      If you lunch interactive mode wit TRIM, the expression is
                      evaluated once you exit (done, quit, exit...)
                      it is the same as launching parser.cmd.ParserCmd main class
@@ -102,51 +113,74 @@ java -jar parser-ng-0.1.7.jar  -h
   Without any parameter, input is considered as math expression and calculated
   without trim, it would be the same as launching parser.MathExpression main class
   run help in verbose mode (-h -v) to get examples
+
 ```
-You  can get examples
+You  can get examples by verbose help:
 ```
-java -jar parser-ng-0.1.7.jar  -h -v
+java -jar parser-ng-0.1.8.jar  -h -v
 ```
-Note, that parser.MathExpression nor parser.cmd.ParserCmd classes works as stand alone working main methods, but  do not take any parameters except expressions
+you can list functions:
+```
+java -jar parser-ng-0.1.8.jar  help
+List of currently known methods:
+acos        - help not yet written. See https://github.com/gbenroscience/ParserNG
+...
+variance    - help not yet written. See https://github.com/gbenroscience/ParserNG
+List of functions is just tip of iceberg, see: https://github.com/gbenroscience/ParserNG for all features
+```
+you can list logical operators:
+```
+java -jar parser-ng-0.1.8.jar  -l help
+Comparing operators: !=, ==, >=, <=, le, ge, lt, gt, <, >
+Logical operators: impl, xor, imp, eq, or, and, |, &
+As Mathematical parts are using () as brackets, Logical parts must be grouped by [] eg.
+Negation can be done by single ! strictly close attached to [; eg ![true]  is ... false. Some spaces like ! [ are actually ok to
+...
+```
+  Note, that parser.MathExpression nor parser.LogicalExpression classes do not take any parameters except expressions
+  Note, that parser.cmd.ParserCmd class takes single parameter -l/-L/--logic to contorl its evaluation
 
 Program can work with stdin, out and err properly. Can work with multiline input - see `-t` switch. If you ned to work with stdin, use `-i` which is otherwise interactive mode
 
 ### cmdline examples
-Following lines describes, how stdin/aruments are processed, and how different is input/output wit `-t` on/off
+Following lines describes, how stdin/arguments are processed, and how different is input/output with `-t` on/off
 ```
-  java -jar parser-ng-0.1.7.jar -h
+   java -jar parser-ng-0.1.8.jar -h
     this help
-  java -jar parser-ng-0.1.7.jar 1+1
+  java -jar parser-ng-0.1.8.jar 1+1
     2.0
-  java -jar parser-ng-0.1.7.jar "1+1
+  java -jar parser-ng-0.1.8.jar "1+1
                                  +2+2"
     2.0
     4.0
-  java -jar parser-ng-0.1.7.jar -t "1+1
+  java -jar parser-ng-0.1.8.jar -t "1+1
                                     +2+2"
     6.0
-  java -jar parser-ng-0.1.7.jar -i  1+1
+  java -jar parser-ng-0.1.8.jar -i  1+1
     nothing, will expect manual output, and calculate line by line
-  java -jar parser-ng-0.1.7.jar -i -t  1+1
+  java -jar parser-ng-0.1.8.jar -i -t  1+1
     nothing, will expect manual output and calcualte it all as one expression
-  echo 2+2 | java -jar parser-ng-0.1.7.jar  1+1
+  echo 2+2 | java -jar parser-ng-0.1.8.jar  1+1
     2.0
   echo "1+1 
-        +2+2 | java -jar parser-ng-0.1.7.jar -i
+        +2+2 | java -jar parser-ng-0.1.8.jar -i
     2.0
     4.0
   echo "1+1 
-        +2+2 | java -jar parser-ng-0.1.7.jar -i -t
+        +2+2 | java -jar parser-ng-0.1.8.jar -i -t
     6.0
-  java -cp parser-ng-0.1.7.jar parser.cmd.ParserCmd "1+1
+  java -cp parser-ng-0.1.8.jar parser.cmd.ParserCmd "1+1
     will ask for manual imput en evaluate per line
   echo "1+1 
-        +2+2 | java -cp parser-ng-0.1.7.jar parser.cmd.ParserCmd 2>/dev/null
+        +2+2 | java -cp parser-ng-0.1.8.jar parser.cmd.ParserCmd 2>/dev/null
     2.0
     4.0
-  java -cp parser-ng-0.1.7.jar parser.MathExpression "1+1
+  java -cp parser-ng-0.1.8.jar parser.MathExpression "1+1
                                                       +2+2"
     6.0
+  java -cp parser-ng-0.1.8.jar parser.LogicalExpression "true or false"
+    true
+
 ```
 
 ## Using ParserNG as library
@@ -683,6 +717,120 @@ If you did:
 This would give:
 
      anon3=@(n)(20883.0*n^0.0+1155.0*n^1.0-1667.0*n^2.0+30.0*n^4.0-1.0*n^5.0+35.0*n^3.0)
+
+## Logical Calculus
+
+The logical expressions in math engine have theirs intentional limitations. Thus allmighty logical expression parser was added around individually evaluated Mathematical expressions which results can be later compared, and logically grouped.  The simplest way to evaluate an logical  expression in ParserNG is to use the <code>LogicalExpression</code> class.
+<code>LogicalExpression</code> is the class responsible for basic comaprsions and logica  expression parsing and evaluation. It calls <code>MathExpression</code> to ech of its basic non-logical parts
+
+Do:<br>
+`LogicalExpression expr = new LogicalExpression("[1+1 < (2+0)*1 impl [ [5 == 6 || 33<(22-20)*2 ]xor [ [  5-3 < 2 or 7*(5+2)<=5 ] and 1+1 == 2]]] eq [ true && false ] ");`
+<br>
+`System.out.println("result: " + expr.solve());`
+<br>
+`true`
+
+<span>What does this do? it will call new MathExpression(...) to each math expression, then comapre them all and then do logicla operations above resulting booleans</span> 
+```
+brackets: [1+1 < (2+0)*1 impl [ [5 == 6 || 33<(22-20)*2 ]xor [ [  5-3 < 2 or 7*(5+2)<=5 ] and 1+1 == 2]]] eq [ true && false ] 
+  brackets: 1+1 < (2+0)*1 impl [ [5 == 6 || 33<(22-20)*2 ]xor [ [  5-3 < 2 or 7*(5+2)<=5 ] and 1+1 == 2]]
+    brackets:  [5 == 6 || 33<(22-20)*2 ]xor [ [  5-3 < 2 or 7*(5+2)<=5 ] and 1+1 == 2]
+        evaluating: 5 == 6 || 33<(22-20)*2 
+          evaluating: 5 == 6
+            evaluating: 5
+            is: 5
+            evaluating: 6
+            is: 6
+          ... 5 == 6
+          is: false
+          evaluating: 33<(22-20)*2 
+            evaluating: 33
+            is: 33
+            evaluating: (22-20)*2 
+            is: 4.0
+          ... 33 < 4.0
+          is: false
+        ... false | false
+        is: false
+    to:   false xor [ [  5-3 < 2 or 7*(5+2)<=5 ] and 1+1 == 2]
+      brackets:  [  5-3 < 2 or 7*(5+2)<=5 ] and 1+1 == 2
+          evaluating:   5-3 < 2 or 7*(5+2)<=5 
+            evaluating:   5-3 < 2
+              evaluating:   5-3
+              is: 2.0
+              evaluating: 2
+              is: 2
+            ... 2.0 < 2
+            is: false
+            evaluating: 7*(5+2)<=5 
+              evaluating: 7*(5+2)
+              is: 49.0
+              evaluating: 5 
+              is: 5
+            ... 49.0 <= 5
+            is: false
+          ... false or false
+          is: false
+      to:   false  and 1+1 == 2
+          evaluating:   false  and 1+1 == 2
+            evaluating:   false
+            is: false
+            evaluating: 1+1 == 2
+              evaluating: 1+1
+              is: 2.0
+              evaluating: 2
+              is: 2
+            ... 2.0 == 2
+            is: true
+          ... false and true
+          is: false
+    to:   false xor  false 
+        evaluating:   false xor  false 
+          evaluating:   false
+          is: false
+          evaluating: false 
+          is: false
+        ... false xor false
+        is: false
+  to: 1+1 < (2+0)*1 impl  false 
+      evaluating: 1+1 < (2+0)*1 impl  false 
+        evaluating: 1+1 < (2+0)*1
+          evaluating: 1+1
+          is: 2.0
+          evaluating: (2+0)*1
+          is: 2.0
+        ... 2.0 < 2.0
+        is: false
+        evaluating: false 
+        is: false
+      ... false impl false
+to:  true  eq [ true && false ] 
+    evaluating:  true && false 
+      evaluating:  true
+      is: true
+      evaluating: false 
+      is: false
+    ... true & false
+    is: false
+to:  true  eq  false  
+    evaluating:  true  eq  false  
+      evaluating:  true
+      is: true
+      evaluating: false  
+      is: false
+    ... true eq false
+    is: false
+false
+```
+Note, that logical parsser supports only dual operators, so where true|false|true is valid, 1<2<3  is invalid!
+Thus:  [1<2]<3   is necessary and  even  [[true|false]|true]is recomeded to be used, For 1<2<3  exception is thrown.
+Single letter can logical operands can be used in row. So eg | have same meaning as ||. But also unluckily also eg < is same as <<
+Negation can be done by single ! strictly close attached to [; eg ![true]  is ... false. Some spaces like ! [ are actually ok to
+Note, that variables works, but must be included in first evaluated expression. Which is obvious for "r=3;r<r+1"
+But much less for [r=3;r<r+1 || [r<5]]", which fails and must be declared as "[r<r+1 || [r=3;r<5]]"
+To avoid this, you can declare all in first dummy expression: "[r=3;r<1] || [r<r+1 || [r<5]]" which ensure theirs allocation ahead of time and do not affect the rest
+If you modify the variables, in the subseqet calls, results maybe funny. Use verbose mode to debug order
+
 
 ## TO BE CONTINUED
 And much more!

--- a/src/main/java/math/Main.java
+++ b/src/main/java/math/Main.java
@@ -6,12 +6,13 @@ import java.util.Arrays;
 import java.util.List;
 
 import interfaces.Solvable;
+import parser.LogicalExpression;
 import parser.MathExpression;
 import parser.cmd.ParserCmd;
 
 public class Main {
 
-    private static class MultiSwitch {
+    public static class MultiSwitch {
         private final String[] switches;
 
         public MultiSwitch(String... switches) {
@@ -22,6 +23,15 @@ public class Main {
             for (String s : switches) {
                 l.remove(s);
             }
+        }
+
+        public boolean isIn(String l) {
+            for (String s : switches) {
+                if (l.equals(s)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         public boolean isContained(List<String> l) {
@@ -54,9 +64,11 @@ public class Main {
     private static final MultiSwitch trimSwitch = new MultiSwitch("-t", "-T", "--trim");
     private static final MultiSwitch helpSwitch = new MultiSwitch("-h", "-H", "--help");
     private static final MultiSwitch interactiveSwitch = new MultiSwitch("-i", "-I", "--interactive");
+    private static final MultiSwitch logcalSwitch = new MultiSwitch("-l", "-L", "--logic");
 
     private static boolean trim = false;
     private static boolean verbose = false;
+    private static boolean logic = false;
 
     public static void main(String... args) throws IOException {
         List<String> aargs = new ArrayList<>(Arrays.asList(args));
@@ -69,6 +81,10 @@ public class Main {
             trim = true;
             trimSwitch.removeFrom(aargs);
         }
+        if (logcalSwitch.isContained(aargs)) {
+            logic = true;
+            logcalSwitch.removeFrom(aargs);
+        }
         if (helpSwitch.isContained(aargs)) {
             help();
             if (isVerbose()) {
@@ -79,7 +95,7 @@ public class Main {
             if (aargs.size() > 0) {
                 System.err.println(interactiveSwitch.toString() + " is interactive mode, commandline expression omitted");
             }
-            ParserCmd.main(null);
+            ParserCmd.main(new String[0]);
         } else {
             String[] exs = joinArgs(aargs, trim).split("\n");
             for (String ex : exs) {
@@ -88,19 +104,29 @@ public class Main {
                     System.err.println(ex);
                     System.err.flush();
                 }
-                Solvable exp = new MathExpression(ex);
-                String r = exp.solve();
+                String r = null;
+                try {
+                    Solvable exp = logic ? new LogicalExpression(ex, LogicalExpression.verboseStderrLogger) : new MathExpression(ex);
+                    r  = exp.solve();
+                }catch(Exception fatal){
+                    if (verbose){
+                        throw fatal;
+                    } else {
+                        r = fatal.getMessage();
+                    }
+                }
                 System.out.println(r);
             }
         }
-        //switch math  logical (-l/-L/--logic),
-        // add main method to pom
     }
 
     static void help() {
         System.out.println("  ParserNG " + getVersion() + " " + Main.class.getName());
         System.out.println(helpSwitch + "         this text; do not change for help (witout dashes), which lists functions");
         System.out.println(verboseSwitch + "      output is reprinted to stderr with some inter-steps");
+        System.out.println(logcalSwitch + "        will add logical expression wrapper around the expression");
+        System.out.println("                     Logical expression parser is much less evolved and slow. Do not use it if you don't must");
+        System.out.println("                     If you use logical parse, result is always true/false. If it is not understood, it reuslts to false");
         System.out.println(trimSwitch + "         by default, each line is one expression,");
         System.out.println("                     however for better redability, sometimes it is worthy to");
         System.out.println("                     to split the expression to multiple lines. and evaluate as one.");
@@ -150,7 +176,11 @@ public class Main {
         System.out.println("  java -cp parser-ng-" + getVersion() + ".jar " + MathExpression.class.getName() + " \"1+1\n"
                 + "                                                      +2+2\"");
         System.out.println("    6.0");
-        System.out.println("  Note, that " + MathExpression.class.getName() + " nor " + ParserCmd.class.getName() + " classes do not take any aprameters except expressions");
+        System.out.println("  java -cp parser-ng-" + getVersion() + ".jar " + LogicalExpression.class.getName() + " \"true or false\"");
+        System.out.println("    true");
+        System.out.println("  Note, that " + MathExpression.class.getName() + " nor " + LogicalExpression.class.getName() + " classes do not take any parameters except expressions");
+        System.out.println("  Note, that " + ParserCmd.class.getName() + " class takes single parameter " + logcalSwitch + " to contorl its evaluation");
+        System.out.println(LogicalExpression.getHelp());
     }
 
     public static String joinArgs(List<String> filteredArgs, boolean trim) {
@@ -174,8 +204,20 @@ public class Main {
         return verbose;
     }
 
+    public static boolean isLogic() {
+        return logic;
+    }
+
+    public static void setLogic(boolean logic) {
+        Main.logic = logic;
+    }
+
     public static String getVersion() {
         //todo, read from pom. See JRD how we did it
-        return "0.1.7";
+        return "0.1.8";
+    }
+
+    public static MultiSwitch getLogcalSwitch() {
+        return logcalSwitch;
     }
 }

--- a/src/main/java/math/Main.java
+++ b/src/main/java/math/Main.java
@@ -9,6 +9,7 @@ import interfaces.Solvable;
 import parser.LogicalExpression;
 import parser.MathExpression;
 import parser.cmd.ParserCmd;
+import parser.logical.ExpressionLogger;
 
 public class Main {
 
@@ -180,7 +181,7 @@ public class Main {
         System.out.println("    true");
         System.out.println("  Note, that " + MathExpression.class.getName() + " nor " + LogicalExpression.class.getName() + " classes do not take any parameters except expressions");
         System.out.println("  Note, that " + ParserCmd.class.getName() + " class takes single parameter " + logcalSwitch + " to contorl its evaluation");
-        System.out.println(LogicalExpression.getHelp());
+        System.out.println(new LogicalExpression(" 1 == 1", ExpressionLogger.DEV_NULL).getHelp());
     }
 
     public static String joinArgs(List<String> filteredArgs, boolean trim) {

--- a/src/main/java/parser/LogicalExpression.java
+++ b/src/main/java/parser/LogicalExpression.java
@@ -29,10 +29,8 @@ public class LogicalExpression implements Solvable {
     }
 
     public static void main(String args[]) {
-        String in  = Main.joinArgs(Arrays.asList(args), true);
-        if (Main.isVerbose()) {
-            System.err.println(in);
-        }
+        String in = Main.joinArgs(Arrays.asList(args), true);
+        verboseStderrLogger.log(in);
         System.out.println(new LogicalExpression(in, verboseStderrLogger).solve());
 
     }//end method
@@ -42,7 +40,11 @@ public class LogicalExpression implements Solvable {
         if (originalExpression.trim().equalsIgnoreCase(Declarations.HELP)) {
             return getHelp();
         }
-        return evalBrackets(originalExpression, mainLogger);
+        if (LogicalExpressionParser.isLogical(originalExpression)) {
+            return evalBrackets(originalExpression, mainLogger);
+        } else {
+            return new MathExpression(originalExpression).solve();
+        }
     }
 
     private String evalBrackets(String ex, ExpressionLogger logger) {
@@ -106,8 +108,8 @@ public class LogicalExpression implements Solvable {
 
 
     public static String getHelp() {
-        return new ComparingExpressionParser(" 1 == 1", ExpressionLogger.DEV_NULL).getHelp()+"\n"+
-               new LogicalExpressionParser(" 1 == 1", ExpressionLogger.DEV_NULL).getHelp() + "\n" +
+        return new ComparingExpressionParser(" 1 == 1", ExpressionLogger.DEV_NULL).getHelp() + "\n" +
+                new LogicalExpressionParser(" 1 == 1", ExpressionLogger.DEV_NULL).getHelp() + "\n" +
                 "As Mathematical parts are using () as brackets, Logical parts must be grouped by [] eg: " + "\n" +
                 "1+1 < (2+0)*1 impl [ [5 == 6 || 33<(22-20)*2 ]xor [ [  5-3 < 2 or 7*(5+2)<=5 ] and 1+1 == 2]] eq [ true && false ]" + "\n" +
                 "Note, that logical parsser supports only dual operators, so where true|false|true is valid, 1<2<3  is invalid!" + "\n" +

--- a/src/main/java/parser/LogicalExpression.java
+++ b/src/main/java/parser/LogicalExpression.java
@@ -1,0 +1,123 @@
+package parser;
+
+import interfaces.Solvable;
+import math.Main;
+import parser.logical.ComparingExpressionParser;
+import parser.logical.ExpressionLogger;
+import parser.logical.LogicalExpressionParser;
+import parser.methods.Declarations;
+
+import java.util.Arrays;
+
+public class LogicalExpression implements Solvable {
+
+    private final String originalExpression;
+    private final ExpressionLogger mainLogger;
+
+    public static final ExpressionLogger verboseStderrLogger = new ExpressionLogger() {
+        @Override
+        public void log(String s) {
+            if (Main.isVerbose()) {
+                System.err.println(s);
+            }
+        }
+    };
+
+    public LogicalExpression(String s, ExpressionLogger logger) {
+        this.originalExpression = s;
+        this.mainLogger = logger;
+    }
+
+    public static void main(String args[]) {
+        String in  = Main.joinArgs(Arrays.asList(args), true);
+        if (Main.isVerbose()) {
+            System.err.println(in);
+        }
+        System.out.println(new LogicalExpression(in, verboseStderrLogger).solve());
+
+    }//end method
+
+    @Override
+    public String solve() {
+        if (originalExpression.trim().equalsIgnoreCase(Declarations.HELP)) {
+            return getHelp();
+        }
+        return evalBrackets(originalExpression, mainLogger);
+    }
+
+    private String evalBrackets(String ex, ExpressionLogger logger) {
+        logger.log("brackets: " + ex);
+        for (int x = 0; x < ex.length(); x++) {
+            if (ex.charAt(x) == '[') {
+                int neg = -1;
+                int steps = 0;
+                for (int z = x - 1; z >= 0; z--) {
+                    steps++;
+                    if (ex.charAt(z) == '!') {
+                        neg = steps;
+                        break;
+                    }
+                    if (ex.charAt(z) != ' ' && ex.charAt(z) != '\n' && ex.charAt(z) != '\t') {
+                        break;
+                    }
+                }
+                int c = 1;
+                for (int y = x + 1; y < ex.length(); y++) {
+                    if (ex.charAt(y) == '[') {
+                        c++;
+                    }
+                    if (ex.charAt(y) == ']') {
+                        c--;
+                        if (c == 0) {
+                            String s = ex.substring(x + 1, y);
+                            String eval = null;
+                            if (s.contains("[")) {
+                                eval = evalBrackets(s, new ExpressionLogger.InheritingExpressionLogger(logger));
+                            } else {
+                                eval = evalDirect(s, new ExpressionLogger.InheritingExpressionLogger(logger));
+                            }
+                            if (neg >= 0) {
+                                x = x - neg;//!!!!
+                                ExpressionLogger tmpl = new ExpressionLogger.InheritingExpressionLogger(logger);
+                                tmpl.log("!" + eval);
+                                boolean b = !ComparingExpressionParser.parseBooleanStrict(eval.trim());
+                                tmpl.log("..." + b);
+                                eval = "" + b;
+                            }
+                            String s1 = ex.substring(0, x);
+                            String s2 = ex.substring(y + 1);
+                            ex = s1 + " " + eval + " " + s2;
+                            logger.log("to: " + ex);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        String r = evalDirect(ex, new ExpressionLogger.InheritingExpressionLogger(logger));
+        logger.log(r);
+        return r;
+    }
+
+    private String evalDirect(String s, ExpressionLogger logger) {
+        LogicalExpressionParser lex = new LogicalExpressionParser(s, new ExpressionLogger.InheritingExpressionLogger(logger));
+        return "" + lex.evaluate();
+    }
+
+
+    public static String getHelp() {
+        return new ComparingExpressionParser(" 1 == 1", ExpressionLogger.DEV_NULL).getHelp()+"\n"+
+               new LogicalExpressionParser(" 1 == 1", ExpressionLogger.DEV_NULL).getHelp() + "\n" +
+                "As Mathematical parts are using () as brackets, Logical parts must be grouped by [] eg: " + "\n" +
+                "1+1 < (2+0)*1 impl [ [5 == 6 || 33<(22-20)*2 ]xor [ [  5-3 < 2 or 7*(5+2)<=5 ] and 1+1 == 2]] eq [ true && false ]" + "\n" +
+                "Note, that logical parsser supports only dual operators, so where true|false|true is valid, 1<2<3  is invalid!" + "\n" +
+                "Thus:  [1<2]<3   is necessary and  even  [[true|false]|true]is recomeded to be used, For 1<2<3  exception is thrown. " + "\n" +
+                "Single letter can logical operands can be used in row. So eg | have same meaning as ||. But also unluckily also eg < is same as <<" + "\n" +
+                "Negation can be done by single ! strictly close attached to [; eg ![true]  is ... false. Some spaces like ! [ are actually ok too\n" +
+                "Note, that variables works, but must be included in first evaluated expression. Which is obvious for \"r=3;r<r+1\"\n" +
+                "But much less for [r=3;r<r+1 || [r<5]]\", which fails and must be declared as \"[r<r+1 || [r=3;r<5]]\" \n" +
+                "To avoid this, you can declare all in first dummy expression: \"[r=3;r<1] || [r<r+1 || [r<5]]\" which ensure theirs allocation ahead of time and do not affect the rest\n" +
+                "If you modify the variables, in the subseqet calls, results maybe funny. Use verbose mode to debug order";
+
+    }
+}

--- a/src/main/java/parser/LogicalExpression.java
+++ b/src/main/java/parser/LogicalExpression.java
@@ -82,7 +82,7 @@ public class LogicalExpression implements Solvable {
                                 x = x - neg;//!!!!
                                 ExpressionLogger tmpl = new ExpressionLogger.InheritingExpressionLogger(logger);
                                 tmpl.log("!" + eval);
-                                boolean b = !ComparingExpressionParser.parseBooleanStrict(eval.trim());
+                                boolean b = !ComparingExpressionParser.parseBooleanStrict(eval.trim(), logger);
                                 tmpl.log("..." + b);
                                 eval = "" + b;
                             }

--- a/src/main/java/parser/MathExpression.java
+++ b/src/main/java/parser/MathExpression.java
@@ -1384,6 +1384,7 @@ public class MathExpression implements Savable, Solvable {
      *
      * @return the result of the evaluation
      */
+    @Override
     public String solve() {
         if (expression.equalsIgnoreCase("(" + Declarations.HELP + ")")) {
             return Help.getHelp();

--- a/src/main/java/parser/cmd/ParserCmd.java
+++ b/src/main/java/parser/cmd/ParserCmd.java
@@ -10,10 +10,10 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Scanner;
 
 import interfaces.Solvable;
 import math.Main;
+import parser.LogicalExpression;
 import parser.MathExpression;
 
 /**
@@ -25,10 +25,15 @@ public class ParserCmd {
 
     public static void main(String[] args) throws IOException {
 
+        if (args.length > 0) {
+            if (Main.getLogcalSwitch().isIn(args[0])) {
+                Main.setLogic(true);
+            }
+        }
         BufferedReader sc = new BufferedReader(new InputStreamReader(System.in));
 
         System.err.println("Welcome To ParserNG Command Line");
-        String title = Main.isTrim() ? "Line" : "Question";
+        String title = Main.isTrim() ? Main.isLogic() ? "Logical Line" : "Math Line" : Main.isLogic() ? "Logical Question" : "Math Question";
         int i = 0;
         List<String> batch = new ArrayList<>();
         while (true) {
@@ -59,8 +64,13 @@ public class ParserCmd {
     }
 
     private static void calWitOutput(String cmd) {
-        Solvable expression = new MathExpression(cmd);
-        String ans = expression.solve();
+        String ans = null;
+        try {
+            Solvable expression = Main.isLogic() ? new LogicalExpression(cmd, LogicalExpression.verboseStderrLogger) : new MathExpression(cmd);
+            ans = expression.solve();
+        }catch (Exception ex) {
+            ans = ex.getMessage();
+        }
         System.err.printf("Answer%s\n", divider);
         System.err.flush();
         System.out.println(ans);

--- a/src/main/java/parser/logical/AbstractSplittingParser.java
+++ b/src/main/java/parser/logical/AbstractSplittingParser.java
@@ -15,6 +15,17 @@ public abstract class AbstractSplittingParser {
     protected final List<String> split;
     protected final ExpressionLogger log;
 
+    /**
+     * Dummy constructor to make more easy overriding
+     **/
+    public AbstractSplittingParser() {
+        pattern1 = Pattern.compile(".*");
+        pattern2 = pattern1;
+        original = pattern1.toString();
+        split = new ArrayList<>(0);
+        log = ExpressionLogger.DEV_NULL;
+    }
+
     public AbstractSplittingParser(String expression, ExpressionLogger log) {
         this.log = log;
         pattern1 = toPattern(getPrimaryChars1(), getPrimaryChars2());

--- a/src/main/java/parser/logical/AbstractSplittingParser.java
+++ b/src/main/java/parser/logical/AbstractSplittingParser.java
@@ -1,0 +1,115 @@
+package parser.logical;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public abstract class AbstractSplittingParser {
+
+    private final Pattern pattern1;
+    private final Pattern pattern2;
+    private final String original;
+    protected final List<String> split;
+    protected final ExpressionLogger log;
+
+    public AbstractSplittingParser(String expression, ExpressionLogger log) {
+        this.log = log;
+        pattern1 = toPattern(getPrimaryChars());
+        if (getSecondaryChars().length > 0) {
+            pattern2 = toPattern(getSecondaryChars());
+        } else {
+            pattern2 = null;
+        }
+        this.original = expression;
+        split = split(original);
+    }
+
+    private static Pattern toPattern(String[] chars) {
+        return Pattern.compile("\\s*(" + joinAsOr1n(escape(chars)) + ")\\s*");
+    }
+
+    List<String> split(String expression) {
+        List<String> r = new ArrayList();
+        while (true) {
+            Matcher m = pattern1.matcher(expression);
+            String[] chars = getPrimaryChars();
+            boolean found = m.find();
+            if (!found && getSecondaryChars().length > 0) {
+                m = pattern2.matcher(expression);
+                chars = getSecondaryChars();
+                found = m.find();
+            }
+            if (!found) {
+                r.add(expression);
+                break;
+            }
+            String group = m.group();
+            int start = m.start();
+            int end = m.end();
+            String part = expression.substring(0, start);
+            String sanitizedGroup = group.trim();
+            for (String ch : chars) {
+                sanitizedGroup = sanitizedGroup.replaceAll("(" + escape(ch) + ")+", ch);
+            }
+            r.add(part);
+            r.add(sanitizedGroup);
+            expression = expression.substring(end);
+        }
+        return r;
+    }
+
+    private static String joinAsOr1n(String[] chars) {
+        return Arrays.stream(chars).collect(Collectors.joining("+|")) + "+";
+    }
+
+    private static String[] escape(String[] chars) {
+        String[] r = new String[chars.length];
+        for (int i = 0; i < chars.length; i++) {
+            r[i] = escape(chars[i]);
+        }
+        return r;
+    }
+
+    private static String escape(String s) {
+        if ("&".equals(s) || "|".equals(s)) {
+            return "\\" + s;
+        } else {
+            return s;
+        }
+    }
+
+    public String getOriginal() {
+        return original;
+    }
+
+    public abstract boolean evaluate();
+
+    /**
+     * Primary characters are processed first. Seondary second.
+     * The reason is, if some char is substring of another. Then first msut go the longer ones (which may contain secondary as substring)
+     * the goes secondary. Yah. it can be done bette.. by sorting by lenght and so on... but maybe next tim
+     *
+     * @return strings which are substituted first
+     */
+    public abstract String[] getPrimaryChars();
+
+    /**
+     * Primary characters are processed first. Seondary second.
+     * The reason is, if some char is substring of another. Then first msut go the longer ones (which may contain secondary as substring)
+     * the goes secondary. Yah. it can be done bette.. by sorting by lenght and so on... but maybe next tim
+     *
+     * @return characters which are subsituted second
+     */
+    public abstract String[] getSecondaryChars();
+
+    public String getHelp() {
+        return this.getName() + ": " +
+                Arrays.stream(getPrimaryChars()).collect(Collectors.joining(", ")) + ", " +
+                Arrays.stream(getSecondaryChars()).collect(Collectors.joining(", "));
+    }
+
+    public abstract String getName();
+}

--- a/src/main/java/parser/logical/AbstractSplittingParser.java
+++ b/src/main/java/parser/logical/AbstractSplittingParser.java
@@ -17,9 +17,9 @@ public abstract class AbstractSplittingParser {
 
     public AbstractSplittingParser(String expression, ExpressionLogger log) {
         this.log = log;
-        pattern1 = toPattern(getPrimaryChars());
-        if (getSecondaryChars().length > 0) {
-            pattern2 = toPattern(getSecondaryChars());
+        pattern1 = toPattern(getPrimaryChars1(), getPrimaryChars2());
+        if (getSecondaryChars1().length > 0 || getSecondaryChars2().length > 0) {
+            pattern2 = toPattern(getSecondaryChars1(), getSecondaryChars2());
         } else {
             pattern2 = null;
         }
@@ -27,19 +27,33 @@ public abstract class AbstractSplittingParser {
         split = split(original);
     }
 
-    private static Pattern toPattern(String[] chars) {
-        return Pattern.compile("\\s*(" + joinAsOr1n(escape(chars)) + ")\\s*");
+    protected Pattern toPattern(String[] chars1, String[] chars2) {
+        String p1 = null;
+        if (chars1.length > 0) {
+            p1 = "\\s*(" + joinAsOr1n(escape(chars1)) + ")\\s*";
+        }
+        String p2 = null;
+        if (chars2.length > 0) {
+            p2 = "\\s+(" + joinAsOr1n(escape(chars2)) + ")\\s+";
+        }
+        if (p1 == null) {
+            return Pattern.compile(p2);
+        }
+        if (p2 == null) {
+            return Pattern.compile(p1);
+        }
+        return Pattern.compile("(" + p1 + ")|(" + p2 + ")");
     }
 
     List<String> split(String expression) {
         List<String> r = new ArrayList();
         while (true) {
             Matcher m = pattern1.matcher(expression);
-            String[] chars = getPrimaryChars();
+            String[] chars = concatWithArrayCopy(getPrimaryChars1(), getPrimaryChars2());
             boolean found = m.find();
-            if (!found && getSecondaryChars().length > 0) {
+            if (!found && concatWithArrayCopy(getSecondaryChars1(), getSecondaryChars2()).length > 0) {
                 m = pattern2.matcher(expression);
-                chars = getSecondaryChars();
+                chars = concatWithArrayCopy(getSecondaryChars1(), getSecondaryChars2());
                 found = m.find();
             }
             if (!found) {
@@ -54,7 +68,7 @@ public abstract class AbstractSplittingParser {
             for (String ch : chars) {
                 sanitizedGroup = sanitizedGroup.replaceAll("(" + escape(ch) + ")+", ch);
             }
-            r.add(part);
+            r.addAll(split(part));
             r.add(sanitizedGroup);
             expression = expression.substring(end);
         }
@@ -63,6 +77,12 @@ public abstract class AbstractSplittingParser {
 
     private static String joinAsOr1n(String[] chars) {
         return Arrays.stream(chars).collect(Collectors.joining("+|")) + "+";
+    }
+
+    static String[] concatWithArrayCopy(String[] array1, String[] array2) {
+        String[] result = Arrays.copyOf(array1, array1.length + array2.length);
+        System.arraycopy(array2, 0, result, array1.length, array2.length);
+        return result;
     }
 
     private static String[] escape(String[] chars) {
@@ -92,23 +112,52 @@ public abstract class AbstractSplittingParser {
      * The reason is, if some char is substring of another. Then first msut go the longer ones (which may contain secondary as substring)
      * the goes secondary. Yah. it can be done bette.. by sorting by lenght and so on... but maybe next tim
      *
+     * PrimaryChars1 are allowed without spaces
+     *
      * @return strings which are substituted first
      */
-    public abstract String[] getPrimaryChars();
+    public abstract String[] getPrimaryChars1();
 
     /**
      * Primary characters are processed first. Seondary second.
      * The reason is, if some char is substring of another. Then first msut go the longer ones (which may contain secondary as substring)
      * the goes secondary. Yah. it can be done bette.. by sorting by lenght and so on... but maybe next tim
      *
+     * PrimaryChars2 are NOT allowed without spaces
+     *
+     * @return strings which are substituted first
+     */
+    public abstract String[] getPrimaryChars2();
+
+    /**
+     * Primary characters are processed first. Seondary second.
+     * The reason is, if some char is substring of another. Then first msut go the longer ones (which may contain secondary as substring)
+     * the goes secondary. Yah. it can be done bette.. by sorting by lenght and so on... but maybe next tim
+     *
+     * SecondaryChars1 are allowed without spaces
+     *
      * @return characters which are subsituted second
      */
-    public abstract String[] getSecondaryChars();
+
+    public abstract String[] getSecondaryChars1();
+
+    /**
+     * Primary characters are processed first. Seondary second.
+     * The reason is, if some char is substring of another. Then first msut go the longer ones (which may contain secondary as substring)
+     * the goes secondary. Yah. it can be done bette.. by sorting by lenght and so on... but maybe next tim
+     *
+     * SecondaryChars2 are NOT allowed without spaces
+     *
+     * @return characters which are subsituted second
+     */
+    public abstract String[] getSecondaryChars2();
 
     public String getHelp() {
-        return this.getName() + ": " +
-                Arrays.stream(getPrimaryChars()).collect(Collectors.joining(", ")) + ", " +
-                Arrays.stream(getSecondaryChars()).collect(Collectors.joining(", "));
+        return this.getName() + " - " +
+                "allowed with spaces:" + Arrays.stream(getPrimaryChars1()).collect(Collectors.joining(", ")) + ", " +
+                "" + Arrays.stream(getSecondaryChars1()).collect(Collectors.joining(", ")) +
+                "; not allowed with spaces:" + Arrays.stream(getPrimaryChars2()).collect(Collectors.joining(", ")) + ", " +
+                "" + Arrays.stream(getSecondaryChars2()).collect(Collectors.joining(", "));
     }
 
     public abstract String getName();

--- a/src/main/java/parser/logical/AlgebraExpressionParser.java
+++ b/src/main/java/parser/logical/AlgebraExpressionParser.java
@@ -17,7 +17,7 @@ public class AlgebraExpressionParser {
     }
 
     public BigDecimal evaluate() {
-        log.log("evaluating: " + original);
+        log.log("evaluating math: " + original);
         BigDecimal r =  new BigDecimal(mathExpression.solve());
         log.log("is: " + r.toString());
         return r;

--- a/src/main/java/parser/logical/AlgebraExpressionParser.java
+++ b/src/main/java/parser/logical/AlgebraExpressionParser.java
@@ -1,0 +1,25 @@
+package parser.logical;
+
+import parser.MathExpression;
+
+import java.math.BigDecimal;
+
+public class AlgebraExpressionParser {
+
+    private final MathExpression mathExpression;
+    private final String original;
+    private final ExpressionLogger log;
+
+    public AlgebraExpressionParser(String expr, ExpressionLogger log) {
+        original = expr;
+        this.log = log;
+        mathExpression = new MathExpression(original);
+    }
+
+    public BigDecimal evaluate() {
+        log.log("evaluating: " + original);
+        BigDecimal r =  new BigDecimal(mathExpression.solve());
+        log.log("is: " + r.toString());
+        return r;
+    }
+}

--- a/src/main/java/parser/logical/ComparingExpressionParser.java
+++ b/src/main/java/parser/logical/ComparingExpressionParser.java
@@ -1,0 +1,81 @@
+package parser.logical;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+
+public class ComparingExpressionParser extends AbstractSplittingParser {
+
+    private static final String[] primaryChars = new String[]{"!=", "==", ">=", "<=", "le", "ge", "lt", "gt"};
+    private static final String[] secondaryChars = new String[]{"<", ">"};
+
+    public ComparingExpressionParser(String expression, ExpressionLogger log) {
+        super(expression, log);
+
+    }
+
+    public String[] getPrimaryChars() {
+        return Arrays.copyOf(primaryChars, primaryChars.length);
+    }
+
+    public String[] getSecondaryChars() {
+        return Arrays.copyOf(secondaryChars, secondaryChars.length);
+    }
+
+    public boolean evaluate() {
+        log.log("evaluating: " + getOriginal());
+        if (split.size() == 1) {
+            boolean r = parseBooleanStrict(split.get(0).trim());
+            log.log("is: " + r);
+            return r;
+        } else if (split.size() == 3) {
+            BigDecimal result1 = new AlgebraExpressionParser(split.get(0), new ExpressionLogger.InheritingExpressionLogger(log)).evaluate();
+            BigDecimal result2 = new AlgebraExpressionParser(split.get(2), new ExpressionLogger.InheritingExpressionLogger(log)).evaluate();
+            String op = split.get(1);
+            log.log("... " + result1.toString() + " " + op + " " + result2.toString());
+            if (">".equals(op) || "gt".equals(op)) {
+                boolean r = result1.compareTo(result2) > 0;
+                log.log("is: " + r);
+                return r;
+            } else if ("<".equals(op) || "lt".equals(op)) {
+                boolean r = result1.compareTo(result2) < 0;
+                log.log("is: " + r);
+                return r;
+            } else if (">=".equals(op) || "ge".equals(op)) {
+                boolean r = result1.compareTo(result2) >= 0;
+                log.log("is: " + r);
+                return r;
+            } else if ("<=".equals(op) || "le".equals(op)) {
+                boolean r = result1.compareTo(result2) <= 0;
+                log.log("is: " + r);
+                return r;
+            } else if ("!=".equals(op)) {
+                boolean r = result1.compareTo(result2) != 0;
+                log.log("is: " + r);
+                return r;
+            } else if ("==".equals(op)) {
+                boolean r = result1.compareTo(result2) == 0;
+                log.log("is: " + r);
+                return r;
+            } else {
+                throw new ArithmeticException("unknown comparison operator" + op);
+            }
+        } else {
+            throw new ArithmeticException("The comparison operator needs to be operand between operators or true/false. Is " + getOriginal());
+        }
+    }
+
+    public static boolean parseBooleanStrict(String trim) {
+        if ("true".equalsIgnoreCase(trim)) {
+            return true;
+        } else if ("false".equalsIgnoreCase(trim)){
+            return false;
+        } else {
+            throw new ArithmeticException(trim + " is not true/false");
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "Comparing operators";
+    }
+}

--- a/src/main/java/parser/logical/ComparingExpressionParser.java
+++ b/src/main/java/parser/logical/ComparingExpressionParser.java
@@ -10,7 +10,21 @@ public class ComparingExpressionParser extends AbstractSplittingParser {
 
     public ComparingExpressionParser(String expression, ExpressionLogger log) {
         super(expression, log);
+    }
 
+
+    public static boolean isComparing(String originalExpression) {
+        for (String s : primaryChars) {
+            if (originalExpression.contains(s)) {
+                return true;
+            }
+        }
+        for (String s : secondaryChars) {
+            if (originalExpression.contains(s)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public String[] getPrimaryChars() {

--- a/src/main/java/parser/logical/ComparingExpressionParser.java
+++ b/src/main/java/parser/logical/ComparingExpressionParser.java
@@ -3,7 +3,7 @@ package parser.logical;
 import java.math.BigDecimal;
 import java.util.Arrays;
 
-public class ComparingExpressionParser extends AbstractSplittingParser {
+public class ComparingExpressionParser extends AbstractSplittingParser implements LogicalExpressionMemberFactory.LogicalExpressionMember {
 
     private static final String[] primaryChars1 = new String[]{"!=", "==", ">=", "<="};
     private static final String[] primaryChars2 = new String[]{"le", "ge", "lt", "gt"};
@@ -14,8 +14,13 @@ public class ComparingExpressionParser extends AbstractSplittingParser {
         super(expression, log);
     }
 
+    public ComparingExpressionParser() {
+        super();
+    }
 
-    public static boolean isComparing(String originalExpression) {
+
+    @Override
+    public boolean isLogicalExpressionMember(String originalExpression) {
         for (String s : primaryChars1) {
             if (originalExpression.contains(s)) {
                 return true;
@@ -39,22 +44,27 @@ public class ComparingExpressionParser extends AbstractSplittingParser {
         return false;
     }
 
+    @Override
     public String[] getPrimaryChars1() {
         return Arrays.copyOf(primaryChars1, primaryChars1.length);
     }
 
+    @Override
     public String[] getPrimaryChars2() {
         return Arrays.copyOf(primaryChars2, primaryChars2.length);
     }
 
+    @Override
     public String[] getSecondaryChars1() {
         return Arrays.copyOf(secondaryChars1, secondaryChars1.length);
     }
 
+    @Override
     public String[] getSecondaryChars2() {
         return Arrays.copyOf(secondaryChars2, secondaryChars2.length);
     }
 
+    @Override
     public boolean evaluate() {
         log.log("evaluating comparison: " + getOriginal());
         if (split.size() == 1) {
@@ -111,5 +121,13 @@ public class ComparingExpressionParser extends AbstractSplittingParser {
     @Override
     public String getName() {
         return "Comparing operators";
+    }
+
+    public static class ComparingExpressionParserFactory implements  LogicalExpressionMemberFactory {
+
+        @Override
+        public LogicalExpressionMember createLogicalExpressionMember(String expression, ExpressionLogger log) {
+            return new ComparingExpressionParser(expression, log);
+        }
     }
 }

--- a/src/main/java/parser/logical/ComparingExpressionParser.java
+++ b/src/main/java/parser/logical/ComparingExpressionParser.java
@@ -5,8 +5,10 @@ import java.util.Arrays;
 
 public class ComparingExpressionParser extends AbstractSplittingParser {
 
-    private static final String[] primaryChars = new String[]{"!=", "==", ">=", "<=", "le", "ge", "lt", "gt"};
-    private static final String[] secondaryChars = new String[]{"<", ">"};
+    private static final String[] primaryChars1 = new String[]{"!=", "==", ">=", "<="};
+    private static final String[] primaryChars2 = new String[]{"le", "ge", "lt", "gt"};
+    private static final String[] secondaryChars1 = new String[]{"<", ">"};
+    private static final String[] secondaryChars2 = new String[]{};
 
     public ComparingExpressionParser(String expression, ExpressionLogger log) {
         super(expression, log);
@@ -14,12 +16,22 @@ public class ComparingExpressionParser extends AbstractSplittingParser {
 
 
     public static boolean isComparing(String originalExpression) {
-        for (String s : primaryChars) {
+        for (String s : primaryChars1) {
             if (originalExpression.contains(s)) {
                 return true;
             }
         }
-        for (String s : secondaryChars) {
+        for (String s : primaryChars2) {
+            if (originalExpression.contains(s)) {
+                return true;
+            }
+        }
+        for (String s : secondaryChars1) {
+            if (originalExpression.contains(s)) {
+                return true;
+            }
+        }
+        for (String s : secondaryChars2) {
             if (originalExpression.contains(s)) {
                 return true;
             }
@@ -27,18 +39,26 @@ public class ComparingExpressionParser extends AbstractSplittingParser {
         return false;
     }
 
-    public String[] getPrimaryChars() {
-        return Arrays.copyOf(primaryChars, primaryChars.length);
+    public String[] getPrimaryChars1() {
+        return Arrays.copyOf(primaryChars1, primaryChars1.length);
     }
 
-    public String[] getSecondaryChars() {
-        return Arrays.copyOf(secondaryChars, secondaryChars.length);
+    public String[] getPrimaryChars2() {
+        return Arrays.copyOf(primaryChars2, primaryChars2.length);
+    }
+
+    public String[] getSecondaryChars1() {
+        return Arrays.copyOf(secondaryChars1, secondaryChars1.length);
+    }
+
+    public String[] getSecondaryChars2() {
+        return Arrays.copyOf(secondaryChars2, secondaryChars2.length);
     }
 
     public boolean evaluate() {
-        log.log("evaluating: " + getOriginal());
+        log.log("evaluating comparison: " + getOriginal());
         if (split.size() == 1) {
-            boolean r = parseBooleanStrict(split.get(0).trim());
+            boolean r = parseBooleanStrict(split.get(0).trim(), log);
             log.log("is: " + r);
             return r;
         } else if (split.size() == 3) {
@@ -78,10 +98,10 @@ public class ComparingExpressionParser extends AbstractSplittingParser {
         }
     }
 
-    public static boolean parseBooleanStrict(String trim) {
+    public static boolean parseBooleanStrict(String trim, ExpressionLogger log) {
         if ("true".equalsIgnoreCase(trim)) {
             return true;
-        } else if ("false".equalsIgnoreCase(trim)){
+        } else if ("false".equalsIgnoreCase(trim)) {
             return false;
         } else {
             throw new ArithmeticException(trim + " is not true/false");

--- a/src/main/java/parser/logical/ExpressionLogger.java
+++ b/src/main/java/parser/logical/ExpressionLogger.java
@@ -1,0 +1,25 @@
+package parser.logical;
+
+public interface ExpressionLogger {
+
+    public static final class InheritingExpressionLogger implements  ExpressionLogger {
+
+        private final ExpressionLogger parent;
+
+        public InheritingExpressionLogger(ExpressionLogger parent) {
+            this.parent = parent;
+        }
+
+        @Override
+        public void log(String s) {
+            parent.log("  " + s);
+        }
+    }
+    public static ExpressionLogger DEV_NULL = new ExpressionLogger() {
+        @Override
+        public void log(String s) {
+        }
+    };
+
+    public void log(String s);
+}

--- a/src/main/java/parser/logical/LogicalExpressionMemberFactory.java
+++ b/src/main/java/parser/logical/LogicalExpressionMemberFactory.java
@@ -1,0 +1,33 @@
+package parser.logical;
+
+public interface LogicalExpressionMemberFactory {
+
+    LogicalExpressionMember createLogicalExpressionMember(String expression, ExpressionLogger log);
+
+    interface LogicalExpressionMember {
+
+        /**
+         * Help for this parser
+         */
+        String getHelp();
+
+        /**
+         * The method should understand true/false strings, if it is supposed to be used in more complicated expressions.
+         *
+         * @return evaluated expression, usually parsed in constructor
+         */
+        boolean evaluate();
+
+        /**
+         * ParserNG have a habit, that expression is parsed in constructor, and later evaluated in methood.
+         * So this methid is takin parameter, of future expression, created over dummy example, so we know,
+         * whether it will be viable for future constructor.
+         *
+         * @param futureExpression future expression to be passed to constructor
+         * @return whether the expression is most likely targeted for this parser
+         */
+        boolean isLogicalExpressionMember(String futureExpression);
+
+
+    }
+}

--- a/src/main/java/parser/logical/LogicalExpressionParser.java
+++ b/src/main/java/parser/logical/LogicalExpressionParser.java
@@ -1,0 +1,57 @@
+package parser.logical;
+
+
+import java.util.Arrays;
+
+public class LogicalExpressionParser extends AbstractSplittingParser {
+
+    private static final String[] chars = new String[]{"imp", "eq", "or", "and", "|", "&"};
+
+    public LogicalExpressionParser(String expression, ExpressionLogger log) {
+        super(expression, log);
+    }
+
+
+    public String[] getPrimaryChars() {
+        return new String[]{"impl", "xor"};
+    }
+
+    public String[] getSecondaryChars() {
+        return Arrays.copyOf(chars, chars.length);
+    }
+
+    public boolean evaluate() {
+        log.log("evaluating: " + getOriginal());
+        boolean result = new ComparingExpressionParser(split.get(0), new ExpressionLogger.InheritingExpressionLogger(log)).evaluate();
+        for (int i = 1; i <= split.size() - 2; i = i + 2) {
+            String op = split.get(i);
+            ComparingExpressionParser comp2 = new ComparingExpressionParser(split.get(i + 1),new ExpressionLogger.InheritingExpressionLogger(log));
+            boolean r2 = comp2.evaluate();
+            log.log("... " + result + " " + op + " " + r2);
+            if ("&".equals(op) || "and".equals(op)) {
+                result = result && r2;
+            } else if ("|".equals(op) || "or".equals(op)) {
+                result = result || r2;
+            } else if ("impl".equals(op) || "imp".equals(op)) {
+                if (result && !r2) {
+                    return false;
+                } else {
+                    return true;
+                }
+            } else if ("eq".equals(op)) {
+                result = result == r2;
+            } else if ("xor".equals(op)) {
+                result = (result != r2);
+            } else {
+                throw new ArithmeticException("invalid operator " + op);
+            }
+        }
+        log.log("is: " + result);
+        return result;
+    }
+
+    @Override
+    public String getName() {
+        return "Logical operators";
+    }
+}

--- a/src/main/java/parser/logical/LogicalExpressionParser.java
+++ b/src/main/java/parser/logical/LogicalExpressionParser.java
@@ -6,14 +6,37 @@ import java.util.Arrays;
 public class LogicalExpressionParser extends AbstractSplittingParser {
 
     private static final String[] chars = new String[]{"imp", "eq", "or", "and", "|", "&"};
+    private static final String[] secchars = new String[]{"impl", "xor"};
 
     public LogicalExpressionParser(String expression, ExpressionLogger log) {
         super(expression, log);
     }
 
+    public static boolean isLogical(String originalExpression) {
+        for (String s : new String[]{"false", "true"}) {
+            if (originalExpression.toLowerCase().contains(s)) {
+                return true;
+            }
+        }
+        for (String s : chars) {
+            if (originalExpression.contains(s)) {
+                return true;
+            }
+        }
+        for (String s : secchars) {
+            if (originalExpression.contains(s)) {
+                return true;
+            }
+        }
+        if (ComparingExpressionParser.isComparing(originalExpression)){
+            return true;
+        }
+        return false;
+    }
+
 
     public String[] getPrimaryChars() {
-        return new String[]{"impl", "xor"};
+        return Arrays.copyOf(secchars, secchars.length);
     }
 
     public String[] getSecondaryChars() {
@@ -25,7 +48,7 @@ public class LogicalExpressionParser extends AbstractSplittingParser {
         boolean result = new ComparingExpressionParser(split.get(0), new ExpressionLogger.InheritingExpressionLogger(log)).evaluate();
         for (int i = 1; i <= split.size() - 2; i = i + 2) {
             String op = split.get(i);
-            ComparingExpressionParser comp2 = new ComparingExpressionParser(split.get(i + 1),new ExpressionLogger.InheritingExpressionLogger(log));
+            ComparingExpressionParser comp2 = new ComparingExpressionParser(split.get(i + 1), new ExpressionLogger.InheritingExpressionLogger(log));
             boolean r2 = comp2.evaluate();
             log.log("... " + result + " " + op + " " + r2);
             if ("&".equals(op) || "and".equals(op)) {

--- a/src/main/java/parser/logical/LogicalExpressionParser.java
+++ b/src/main/java/parser/logical/LogicalExpressionParser.java
@@ -3,48 +3,75 @@ package parser.logical;
 
 import java.util.Arrays;
 
+import parser.methods.Declarations;
+
 public class LogicalExpressionParser extends AbstractSplittingParser {
 
-    private static final String[] chars = new String[]{"imp", "eq", "or", "and", "|", "&"};
-    private static final String[] secchars = new String[]{"impl", "xor"};
+    private static final String[] chars1 = new String[]{};
+    private static final String[] chars2 = new String[]{"impl", "xor"};
+    private static final String[] secchars1 = new String[]{"|", "&"};
+    private static final String[] secchars2 = new String[]{"imp", "eq", "or", "and"};
 
     public LogicalExpressionParser(String expression, ExpressionLogger log) {
         super(expression, log);
     }
 
     public static boolean isLogical(String originalExpression) {
+        String[] methods = Declarations.getInbuiltMethods();
+        for (String method : methods) {
+            //otherwise eg floor would match or, and thus delegate to Logical parser
+            originalExpression = originalExpression.replace(method, "kNoWnMeThOd");
+        }
         for (String s : new String[]{"false", "true"}) {
             if (originalExpression.toLowerCase().contains(s)) {
                 return true;
             }
         }
-        for (String s : chars) {
+        for (String s : chars1) {
             if (originalExpression.contains(s)) {
                 return true;
             }
         }
-        for (String s : secchars) {
+        for (String s : chars2) {
             if (originalExpression.contains(s)) {
                 return true;
             }
         }
-        if (ComparingExpressionParser.isComparing(originalExpression)){
+        for (String s : secchars1) {
+            if (originalExpression.contains(s)) {
+                return true;
+            }
+        }
+        for (String s : secchars2) {
+            if (originalExpression.contains(s)) {
+                return true;
+            }
+        }
+        if (ComparingExpressionParser.isComparing(originalExpression)) {
             return true;
         }
         return false;
     }
 
 
-    public String[] getPrimaryChars() {
-        return Arrays.copyOf(secchars, secchars.length);
+    public String[] getPrimaryChars1() {
+        return Arrays.copyOf(chars1, chars1.length);
     }
 
-    public String[] getSecondaryChars() {
-        return Arrays.copyOf(chars, chars.length);
+    public String[] getPrimaryChars2() {
+        return Arrays.copyOf(chars2, chars2.length);
+    }
+
+    public String[] getSecondaryChars1() {
+        return Arrays.copyOf(secchars1, secchars1.length);
+    }
+
+    public String[] getSecondaryChars2() {
+        return Arrays.copyOf(secchars2, secchars2.length);
     }
 
     public boolean evaluate() {
-        log.log("evaluating: " + getOriginal());
+        log.log("evaluating logical: " + getOriginal());
         boolean result = new ComparingExpressionParser(split.get(0), new ExpressionLogger.InheritingExpressionLogger(log)).evaluate();
         for (int i = 1; i <= split.size() - 2; i = i + 2) {
             String op = split.get(i);

--- a/src/main/java/parser/methods/Help.java
+++ b/src/main/java/parser/methods/Help.java
@@ -1,7 +1,6 @@
 package parser.methods;
 
 import static  parser.methods.Declarations.*;
-import static  parser.methods.BasicNumericalMethod.*;
 
 public class Help {
 

--- a/src/test/java/parser/LogicalExpressionTest.java
+++ b/src/test/java/parser/LogicalExpressionTest.java
@@ -10,8 +10,14 @@ class LogicalExpressionTest {
 
     @Test
     void solveNonsense() {
-        LogicalExpression expr = new LogicalExpression("1+1 < (2+0)*1 impl [ [5 == 6 || 33<(22-20)*2 ]xor [ [  5-3 < 2 or 7*(5+2)<=5 ] and 1+1 == 2]] eq [ true && false ] ", log);
+        LogicalExpression expr = new LogicalExpression("1+1 < (2+0)*1 impl [ [5 == 6 || 33<(22-20)*2 ] xor [ [  5-3 < 2 or 7*(5+2)<=5 ] and 1+1 == 2]] eq [ true && false ] ", log);
         Assertions.assertEquals("true",expr.solve());
+        LogicalExpression exprPartx = new LogicalExpression("1+1 < (2+0)*1 impl   false", log);
+        Assertions.assertEquals("true",exprPartx.solve());
+        LogicalExpression exprFixedPart1 = new LogicalExpression("[1+1 < (2+0)*1 impl  false ]  eq  false", log);
+        Assertions.assertEquals("false",exprFixedPart1.solve());
+        LogicalExpression exprFixedPart2 = new LogicalExpression("1+1 < (2+0)*1 impl  [ false   eq  false]", log);
+        Assertions.assertEquals("true",exprFixedPart2.solve());
     }
 
     @Test
@@ -82,6 +88,7 @@ class LogicalExpressionTest {
         Assertions.assertEquals("false", expr.solve());
     }
 
+    @Test
     void notMoreWithSpaces() {
         LogicalExpression expr;
         expr = new LogicalExpression("![true] || !    [false] ", log);
@@ -102,19 +109,28 @@ class LogicalExpressionTest {
         Assertions.assertEquals("false", expr.solve());
     }
 
+    @Test
     void variablesWorks() {
         LogicalExpression expr;
-        expr = new LogicalExpression("r=3;r<r+1", log);
+        expr = new LogicalExpression("q=3;q<q+1", log);
         Assertions.assertEquals("true", expr.solve());
-        expr = new LogicalExpression("[r<r+1 || [r=3;r<5]]", log);
+        expr = new LogicalExpression("[q<q+1 || [q=3;q<5]]", log);
         Assertions.assertEquals("true", expr.solve());
-        expr = new LogicalExpression("[r=3;r<1] || [r<r+1 || [r<5]]", log);
+        expr = new LogicalExpression("[q=3;q<1] || [q<q+1 || [q<5]]", log);
         Assertions.assertEquals("true", expr.solve());
     }
 
+    @Test
     void variablesDoNotWorks(){
-        LogicalExpression expr;
-        expr = new LogicalExpression("[r=3;r<r+1 || [r<5]", log);
-        Assertions.assertEquals("Character r is neither a decimal digit number, decimal point, nor \"e\" notation exponential mark.", expr.solve());
+        try {
+            LogicalExpression expr;
+            expr = new LogicalExpression("[s=3;s<s+1 || [s<5]]", log);
+            String s = expr.solve();
+            Assertions.assertEquals("Character s is neither a decimal digit number, decimal point, nor \"e\" notation exponential mark.", s);
+        }catch(NumberFormatException ex){
+            ex.printStackTrace();
+            return;
+        }
+        Assertions.assertTrue(false, "should have thrown");
     }
 }

--- a/src/test/java/parser/LogicalExpressionTest.java
+++ b/src/test/java/parser/LogicalExpressionTest.java
@@ -1,0 +1,116 @@
+package parser;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import parser.logical.PrintingExpressionLogger;
+
+class LogicalExpressionTest {
+
+    private static PrintingExpressionLogger log = new PrintingExpressionLogger();
+
+    @Test
+    void solveNonsense() {
+        LogicalExpression expr = new LogicalExpression("1+1 < (2+0)*1 impl [ [5 == 6 || 33<(22-20)*2 ]xor [ [  5-3 < 2 or 7*(5+2)<=5 ] and 1+1 == 2]] eq [ true && false ] ", log);
+        Assertions.assertEquals("true",expr.solve());
+    }
+
+    @Test
+    void solve() {
+        Assertions.assertEquals("true", new LogicalExpression(" 1<2  && 1< 3", log).solve());
+        Assertions.assertEquals("false", new LogicalExpression(" 1<2  && 1<=0", log).solve());
+        Assertions.assertEquals("true", new LogicalExpression(" 1<2  || 1<=0", log).solve());
+
+        Assertions.assertEquals("true", new LogicalExpression(" [  true  || false ] && [  true  && true ] " , log).solve());
+        Assertions.assertEquals("false", new LogicalExpression(" [  true  && false ] && [  true  && true ] " , log).solve());
+        Assertions.assertEquals("true", new LogicalExpression(" [  true  && false ] || [  true  && true ] " , log).solve());
+
+        Assertions.assertEquals("true", new LogicalExpression(" [  true  || false ] &&  true " , log).solve());
+        Assertions.assertEquals("true", new LogicalExpression("   true  || [ false &&  true ]" , log).solve());
+        Assertions.assertEquals("false", new LogicalExpression(" [  false  || true ] &&  false " , log).solve());
+        Assertions.assertEquals("false", new LogicalExpression("   false  || [ true &&  false ]" , log).solve());
+
+        Assertions.assertEquals("false", new LogicalExpression(" [  false  impl true ] impl  false " , log).solve());
+        Assertions.assertEquals("true" , new LogicalExpression("    false  impl [ true impl  false ]" , log).solve());
+    }
+
+    @Test
+    void not() {
+        LogicalExpression expr = new LogicalExpression("[true]", log);
+        Assertions.assertEquals("true", expr.solve());
+        expr = new LogicalExpression("![true]", log);
+        Assertions.assertEquals("false", expr.solve());
+        expr = new LogicalExpression("[false]", log);
+        Assertions.assertEquals("false", expr.solve());
+        expr = new LogicalExpression("![false]", log);
+        Assertions.assertEquals("true", expr.solve());
+    }
+
+    @Test
+    void notWithSpaces() {
+        LogicalExpression expr = new LogicalExpression("[ true]  ", log);
+        Assertions.assertEquals("true", expr.solve());
+        expr = new LogicalExpression(" ! [ true ]", log);
+        Assertions.assertEquals("false", expr.solve());
+        expr = new LogicalExpression("[false]", log);
+        Assertions.assertEquals("false", expr.solve());
+        expr = new LogicalExpression(" !   [false]", log);
+        Assertions.assertEquals("true", expr.solve());
+    }
+
+    @Test
+    void notMore() {
+        LogicalExpression expr;
+        expr = new LogicalExpression("![true] || ![false] ", log);
+        Assertions.assertEquals("true", expr.solve());
+        expr = new LogicalExpression("![ true && false ]", log);
+        Assertions.assertEquals("true", expr.solve());
+
+        expr = new LogicalExpression("![![true] || ![false] ]", log);
+        Assertions.assertEquals("false",expr.solve());
+        expr = new LogicalExpression("![![ true && false ]]", log);
+        Assertions.assertEquals("false", expr.solve());
+
+        expr = new LogicalExpression("![true] || ![false]  eq  ![ true && false ]", log);
+        Assertions.assertEquals("true", expr.solve());
+        expr = new LogicalExpression("![![true] || ![false]]  eq  ![![ true && false ]]", log);
+        Assertions.assertEquals("true", expr.solve());
+        expr = new LogicalExpression("![![![true] || ![false]]  eq  ![![ true && false ]]]", log);
+        Assertions.assertEquals("false", expr.solve());
+    }
+
+    void notMoreWithSpaces() {
+        LogicalExpression expr;
+        expr = new LogicalExpression("![true] || !    [false] ", log);
+        Assertions.assertEquals("true", expr.solve());
+        expr = new LogicalExpression("  !   [ true && false ]", log);
+        Assertions.assertEquals("true", expr.solve());
+
+        expr = new LogicalExpression("! [ ! [true] ||  ! [false] ]", log);
+        Assertions.assertEquals("false", expr.solve());
+        expr = new LogicalExpression("!   [![ true && false ]]", log);
+        Assertions.assertEquals("false", expr.solve());
+
+        expr = new LogicalExpression("   ![true] ||   ! [false]  eq  ! [ true && false ]", log);
+        Assertions.assertEquals("true", expr.solve());
+        expr = new LogicalExpression("!   [ ! [true] || ![false]]  eq  !    [![ true && false ]]", log);
+        Assertions.assertEquals("true", expr.solve());
+        expr = new LogicalExpression("![ ! [! [true] || ![false]]  eq  ![  ! [ true && false ]]]", log);
+        Assertions.assertEquals("false", expr.solve());
+    }
+
+    void variablesWorks() {
+        LogicalExpression expr;
+        expr = new LogicalExpression("r=3;r<r+1", log);
+        Assertions.assertEquals("true", expr.solve());
+        expr = new LogicalExpression("[r<r+1 || [r=3;r<5]]", log);
+        Assertions.assertEquals("true", expr.solve());
+        expr = new LogicalExpression("[r=3;r<1] || [r<r+1 || [r<5]]", log);
+        Assertions.assertEquals("true", expr.solve());
+    }
+
+    void variablesDoNotWorks(){
+        LogicalExpression expr;
+        expr = new LogicalExpression("[r=3;r<r+1 || [r<5]", log);
+        Assertions.assertEquals("Character r is neither a decimal digit number, decimal point, nor \"e\" notation exponential mark.", expr.solve());
+    }
+}

--- a/src/test/java/parser/LogicalExpressionTest.java
+++ b/src/test/java/parser/LogicalExpressionTest.java
@@ -55,6 +55,10 @@ class LogicalExpressionTest {
         Assertions.assertEquals("false", expr.solve());
         expr = new LogicalExpression(" !   [false]", log);
         Assertions.assertEquals("true", expr.solve());
+        expr = new LogicalExpression("[False]", log);
+        Assertions.assertEquals("false", expr.solve());
+        expr = new LogicalExpression("TRUE", log);
+        Assertions.assertEquals("true", expr.solve());
     }
 
     @Test

--- a/src/test/java/parser/MathExpressionTest.java
+++ b/src/test/java/parser/MathExpressionTest.java
@@ -150,6 +150,10 @@ class MathExpressionTest {
     @Test
     void junkExamples() {
         boolean print = false;
+        //this test is checking content of variables.
+        //some other tests could have set them. Eg
+        //LogicalExpressionTest variablesDoNotWorks and variablestWorks
+        VariableManager.clearVariables();
         MathExpression linear = new MathExpression("M=@(3,3)(3,4,1,2,4,7,9,1,-2);N=@(3,3)(4,1,8,2,1,3,5,1,9);C=matrix_sub(M,N);C;");
         String ls = linear.solve();
         if (print) System.out.println("soln: " + ls);

--- a/src/test/java/parser/logical/AlgebraExpressionParserTest.java
+++ b/src/test/java/parser/logical/AlgebraExpressionParserTest.java
@@ -1,0 +1,23 @@
+package parser.logical;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+class AlgebraExpressionParserTest {
+
+    private static PrintingExpressionLogger log = new PrintingExpressionLogger();
+
+    @Test
+    void evaluateTest() {
+        Assertions.assertEquals(0, new AlgebraExpressionParser("0", log).evaluate().compareTo(new BigDecimal(0)));
+        Assertions.assertEquals(0, new AlgebraExpressionParser("2+3", log).evaluate().compareTo(new BigDecimal(5)));
+        Assertions.assertEquals(0, new AlgebraExpressionParser("2+3*4", log).evaluate().compareTo(new BigDecimal(14)));
+        Assertions.assertEquals(0, new AlgebraExpressionParser("(2+3)*4", log).evaluate().compareTo(new BigDecimal(20)));
+        Assertions.assertEquals(0, new AlgebraExpressionParser("cos(pi)", log).evaluate().compareTo(new BigDecimal(-1)));
+        Assertions.assertEquals(0, new AlgebraExpressionParser("sum(1,2,3,4)", log).evaluate().compareTo(new BigDecimal(10)));
+        Assertions.assertEquals(0, new AlgebraExpressionParser("med(0,5,4)", log).evaluate().compareTo(new BigDecimal(4)));
+        Assertions.assertEquals(0, new AlgebraExpressionParser("avg(0,5,4)", log).evaluate().compareTo(new BigDecimal(3)));
+    }
+}

--- a/src/test/java/parser/logical/ComparingExpressionParserTest.java
+++ b/src/test/java/parser/logical/ComparingExpressionParserTest.java
@@ -1,0 +1,80 @@
+package parser.logical;
+
+import org.junit.jupiter.api.Assertions;
+
+import java.util.List;
+
+class ComparingExpressionParserTest {
+
+    private static PrintingExpressionLogger log = new PrintingExpressionLogger();
+
+    @org.junit.jupiter.api.Test
+    void splitTest1() {
+        List<String> s;
+        ComparingExpressionParser comp;
+        s = new ComparingExpressionParser("not important now", log).split("1+2+3 < 5");
+        Assertions.assertEquals(3, s.size());
+        Assertions.assertEquals("1+2+3", s.get(0));
+        Assertions.assertEquals("<", s.get(1));
+        Assertions.assertEquals("5", s.get(2));
+        s = new ComparingExpressionParser("not important now", log).split("1+2+3 > 5");
+        Assertions.assertEquals(3, s.size());
+        Assertions.assertEquals("1+2+3", s.get(0));
+        Assertions.assertEquals(">", s.get(1));
+        Assertions.assertEquals("5", s.get(2));
+        s = new ComparingExpressionParser("not important now", log).split("1+2+3 == 5");
+        Assertions.assertEquals(3, s.size());
+        Assertions.assertEquals("1+2+3", s.get(0));
+        Assertions.assertEquals("==", s.get(1));
+        Assertions.assertEquals("5", s.get(2));
+        s = new ComparingExpressionParser("not important now", log).split("1+2+3 != 5");
+        Assertions.assertEquals(3, s.size());
+        Assertions.assertEquals("1+2+3", s.get(0));
+        Assertions.assertEquals("!=", s.get(1));
+        Assertions.assertEquals("5", s.get(2));
+        s = new ComparingExpressionParser("not important now", log).split("1+2+3 >= 5");
+        Assertions.assertEquals(3, s.size());
+        Assertions.assertEquals("1+2+3", s.get(0));
+        Assertions.assertEquals(">=", s.get(1));
+        Assertions.assertEquals("5", s.get(2));
+        s = new ComparingExpressionParser("not important now", log).split("1+2+3 <= 5");
+        Assertions.assertEquals(3, s.size());
+        Assertions.assertEquals("1+2+3", s.get(0));
+        Assertions.assertEquals("<=", s.get(1));
+        Assertions.assertEquals("5", s.get(2));
+
+    }
+
+    @org.junit.jupiter.api.Test
+    void evalTest() {
+        ComparingExpressionParser comp;
+        comp = new ComparingExpressionParser("1+2+3 < 2*2", log);
+        Assertions.assertFalse(comp.evaluate());
+        comp = new ComparingExpressionParser("1+2+3 > 2*2", log);
+        Assertions.assertTrue(comp.evaluate());
+        comp = new ComparingExpressionParser("1+2 <= 3*2", log);
+        Assertions.assertTrue(comp.evaluate());
+        comp = new ComparingExpressionParser("1+2+3 <= 3*2", log);
+        Assertions.assertTrue(comp.evaluate());
+        comp = new ComparingExpressionParser("30 <= 3*2", log);
+        Assertions.assertFalse(comp.evaluate());
+        comp = new ComparingExpressionParser("1+2+3 == 3*2", log);
+        Assertions.assertTrue(comp.evaluate());
+        comp = new ComparingExpressionParser("1+2+3 == 3*2+1", log);
+        Assertions.assertFalse(comp.evaluate());
+        comp = new ComparingExpressionParser("1+2+3 != 3*2+1", log);
+        Assertions.assertTrue(comp.evaluate());
+        comp = new ComparingExpressionParser("10 >= 6", log);
+        Assertions.assertTrue(comp.evaluate());
+        comp = new ComparingExpressionParser("1+2+3 >= 6", log);
+        Assertions.assertTrue(comp.evaluate());
+        comp = new ComparingExpressionParser("1+2+3 >= 7", log);
+        Assertions.assertFalse(comp.evaluate());
+
+        comp = new ComparingExpressionParser("  true", log);
+        Assertions.assertTrue(comp.evaluate());
+        comp = new ComparingExpressionParser("false  ", log);
+        Assertions.assertFalse(comp.evaluate());
+    }
+
+}

--- a/src/test/java/parser/logical/LogicalExpressionFactoryTest.java
+++ b/src/test/java/parser/logical/LogicalExpressionFactoryTest.java
@@ -1,0 +1,188 @@
+package parser.logical;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import parser.LogicalExpression;
+
+public class LogicalExpressionFactoryTest {
+
+    private static PrintingExpressionLogger log = new PrintingExpressionLogger();
+
+    private static class AlwaysTrueMemberFactory implements LogicalExpressionMemberFactory {
+        @Override
+        public LogicalExpressionMember createLogicalExpressionMember(String expression, final ExpressionLogger log) {
+            return new LogicalExpressionMember() {
+                @Override
+                public String getHelp() {
+                    return "fake help";
+                }
+
+                @Override
+                public boolean evaluate() {
+                    log.log("fake exposition");
+                    return true;
+                }
+
+                @Override
+                public boolean isLogicalExpressionMember(String futureExpression) {
+                    return false;
+                }
+            };
+        }
+    }
+
+    public static class HogwartsMember implements LogicalExpressionMemberFactory.LogicalExpressionMember {
+
+        private final String expression;
+        private final ExpressionLogger log;
+
+        HogwartsMember(String expression, ExpressionLogger log) {
+            this.expression = expression;
+            this.log = log;
+        }
+
+        @Override
+        public String getHelp() {
+            return "Only Harry and Ron are true Tom is Voldemort!";
+        }
+
+        @Override
+        public boolean evaluate() {
+            log.log("evaluating hogwarts members");
+            if (expression.trim().toLowerCase().matches("tom(.*)")) {
+                return false;
+            } else if (expression.trim().toLowerCase().matches("ron(.*)")) {
+                return true;
+            } else if (expression.trim().toLowerCase().matches("harry(.*)")) {
+                return true;
+            } else if (expression.trim().toLowerCase().matches("true")) {
+                return true;
+            } else if (expression.trim().toLowerCase().matches("false")) {
+                return false;
+            }else {
+                throw new RuntimeException("unknown member of hogwarts - " + expression);
+            }
+        }
+
+        @Override
+        public boolean isLogicalExpressionMember(String futureExpression) {
+            return (futureExpression.toLowerCase().matches("harry(.*)")
+                    || futureExpression.toLowerCase().matches("tom(.*)")
+                    || futureExpression.toLowerCase().matches("ron(.*)"));
+        }
+    }
+
+    public static class HogwartsMemberFactory implements LogicalExpressionMemberFactory {
+        @Override
+        public LogicalExpressionMember createLogicalExpressionMember(String expression, ExpressionLogger log) {
+            return new HogwartsMember(expression, log);
+        }
+    }
+
+    @Test
+    void replacableLogicalExpressionMember() {
+        //correct
+        Assertions.assertTrue(new LogicalExpressionParser("0<1 and -1<2", log).evaluate());
+        Assertions.assertFalse(new LogicalExpressionParser("0>1 and -1<2", log).evaluate());
+        String h1 = new LogicalExpressionParser("true and true", log).getHelp();
+        //custom
+        Assertions.assertTrue(new LogicalExpressionParser("0>1 and -1<2", log, new AlwaysTrueMemberFactory()).evaluate());
+        String h2 = new LogicalExpressionParser("0>1 and -1<2", log, new AlwaysTrueMemberFactory()).getHelp();
+        //not affected
+        Assertions.assertTrue(new LogicalExpressionParser("true and true", log).evaluate());
+        Assertions.assertFalse(new LogicalExpressionParser("false and true", log).evaluate());
+        String h3 = new LogicalExpressionParser("true and true", log).getHelp();
+        Assertions.assertEquals(h1, h2); // jsut the logical part
+        Assertions.assertEquals(h3, h2);
+    }
+
+    @Test
+    void replacableLogicalExpressionMemberBrackets() {
+        //correct
+        Assertions.assertEquals("true", new LogicalExpression("[ 0<1 and -1<2 ] or [ 0<1 and -1<2 ] ", log).solve());
+        Assertions.assertEquals("false", new LogicalExpression("[ 0>1 and -1<2] or [0>1 and -1<2]", log).solve());
+        String h1 = new LogicalExpression("help", log).solve();
+        //custom
+        Assertions.assertEquals("true", new LogicalExpression("[ 0>1 and -1<2] or [0>1 and -1<2]",
+                log, new AlwaysTrueMemberFactory()).solve());
+        String h2 = new LogicalExpression("help",
+                log, new AlwaysTrueMemberFactory()).solve();
+        //not affected
+        Assertions.assertEquals("true", new LogicalExpression("[ 0<1 and -1<2 ] or [ 0<1 and -1<2 ] ", log).solve());
+        Assertions.assertEquals("false", new LogicalExpression("[ 0>1 and -1<2] or [0>1 and -1<2]", log).solve());
+        String h3 = new LogicalExpression("help", log).solve();
+        Assertions.assertEquals(h3, h1);
+        Assertions.assertNotEquals(h3, h2); //combined with factory
+    }
+
+    @Test
+    void isLogicalExpressionMemberTest() {
+        Assertions.assertTrue(new LogicalExpressionParser("", log).isLogicalExpressionMember("0>1 and -1<2"));
+        Assertions.assertTrue(new LogicalExpressionParser("", log).isLogicalExpressionMember("0>1 blah -1<2"));
+        Assertions.assertTrue(new LogicalExpressionParser("", log).isLogicalExpressionMember("ron() and tom()"));
+        Assertions.assertFalse(new LogicalExpressionParser("", log).isLogicalExpressionMember("ron() blah tom()"));
+
+        Assertions.assertTrue(new LogicalExpressionParser("", log, new HogwartsMemberFactory()).isLogicalExpressionMember("0>1 and -1<2"));
+        Assertions.assertFalse(new LogicalExpressionParser("", log, new HogwartsMemberFactory()).isLogicalExpressionMember("0>1 blah -1<2"));
+        Assertions.assertTrue(new LogicalExpressionParser("", log, new HogwartsMemberFactory()).isLogicalExpressionMember("ron() and tom()"));
+        Assertions.assertTrue(new LogicalExpressionParser("", log, new HogwartsMemberFactory()).isLogicalExpressionMember("ron() blah tom()"));
+
+        Assertions.assertTrue(new LogicalExpressionParser("", log).isLogicalExpressionMember("0>1 and -1<2"));
+        Assertions.assertTrue(new LogicalExpressionParser("", log).isLogicalExpressionMember("0>1 blah -1<2"));
+        Assertions.assertTrue(new LogicalExpressionParser("", log).isLogicalExpressionMember("ron() and tom()"));
+        Assertions.assertFalse(new LogicalExpressionParser("", log).isLogicalExpressionMember("ron() blah tom()"));
+    }
+
+    @Test
+    void replacableLogicalExpressionMemberWithException() {
+        //correct
+        Assertions.assertTrue(new LogicalExpressionParser("0<1 and -1<2", log).evaluate());
+        Assertions.assertFalse(new LogicalExpressionParser("0>1 and -1<2", log).evaluate());
+        String h1 = new LogicalExpressionParser("true and true", log).getHelp();
+        //custom
+        Exception ex = null;
+        try {
+            Assertions.assertTrue(new LogicalExpressionParser("0>1 and -1<2", log, new HogwartsMemberFactory()).evaluate());
+        } catch (Exception ex1) {
+            ex = ex1;
+        }
+        Assertions.assertTrue(new LogicalExpressionParser("harry() and ron()", log, new HogwartsMemberFactory()).evaluate());
+        Assertions.assertFalse(new LogicalExpressionParser("tom() and ron()", log, new HogwartsMemberFactory()).evaluate());
+        Assertions.assertNotNull(ex);
+        String h2 = new LogicalExpressionParser("0>1 and -1<2", log, new HogwartsMemberFactory()).getHelp();
+        //not affected
+        Assertions.assertTrue(new LogicalExpressionParser("true and true", log).evaluate());
+        Assertions.assertFalse(new LogicalExpressionParser("false and true", log).evaluate());
+        String h3 = new LogicalExpressionParser("true and true", log).getHelp();
+        Assertions.assertEquals(h1, h2); // jsut the logical part
+        Assertions.assertEquals(h3, h2);
+    }
+
+    @Test
+    void replacableLogicalExpressionMemberBracketsWithException() {
+        //correct
+        Assertions.assertEquals("true", new LogicalExpression("[ 0<1 and -1<2 ] or [ 0<1 and -1<2 ] ", log).solve());
+        Assertions.assertEquals("false", new LogicalExpression("[ 0>1 and -1<2] or [0>1 and -1<2]", log).solve());
+        String h1 = new LogicalExpression("help", log).solve();
+        //custom
+        Exception ex = null;
+        try {
+            Assertions.assertEquals("true", new LogicalExpression("[ 0>1 and -1<2] or [0>1 and -1<2]",
+                    log, new HogwartsMemberFactory()).solve());
+        } catch (Exception ex1) {
+            ex = ex1;
+        }
+        Assertions.assertNotNull(ex);
+        String h2 = new LogicalExpression("help",
+                log, new HogwartsMemberFactory()).solve();
+        Assertions.assertEquals("true", new LogicalExpression("[ harry() and ron()] or [ron() and tom()]",
+                log, new HogwartsMemberFactory()).solve());
+        //not affected
+        Assertions.assertEquals("true", new LogicalExpression("[ 0<1 and -1<2 ] or [ 0<1 and -1<2 ] ", log).solve());
+        Assertions.assertEquals("false", new LogicalExpression("[ 0>1 and -1<2] or [0>1 and -1<2]", log).solve());
+        String h3 = new LogicalExpression("help", log).solve();
+        Assertions.assertEquals(h3, h1);
+        Assertions.assertNotEquals(h3, h2); //combined with factory
+    }
+}

--- a/src/test/java/parser/logical/LogicalExpressionParserTest.java
+++ b/src/test/java/parser/logical/LogicalExpressionParserTest.java
@@ -1,0 +1,187 @@
+package parser.logical;
+
+import org.junit.jupiter.api.Assertions;
+
+import java.util.List;
+
+class LogicalExpressionParserTest {
+
+    private static PrintingExpressionLogger log = new PrintingExpressionLogger();
+
+    @org.junit.jupiter.api.Test
+    void splitTest1() {
+        List<String> s;
+        s = new LogicalExpressionParser("not important now", log).split("1+2+3 < 5");
+        Assertions.assertEquals(1, s.size());
+        Assertions.assertEquals("1+2+3 < 5", s.get(0));
+        s = new LogicalExpressionParser("not important now", log).split("1+2+3<5 & 2+5>7");
+        Assertions.assertEquals(3, s.size());
+        Assertions.assertEquals("1+2+3<5", s.get(0));
+        Assertions.assertEquals("&", s.get(1));
+        Assertions.assertEquals("2+5>7", s.get(2));
+        s = new LogicalExpressionParser("not important now", log).split("1+2+3<5    &&&&2+5>7");
+        Assertions.assertEquals(3, s.size());
+        Assertions.assertEquals("1+2+3<5", s.get(0));
+        Assertions.assertEquals("&", s.get(1));
+        Assertions.assertEquals("2+5>7", s.get(2));
+        s = new LogicalExpressionParser("not important now", log).split("1+2+3<5 | 2+5>7");
+        Assertions.assertEquals(3, s.size());
+        Assertions.assertEquals("1+2+3<5", s.get(0));
+        Assertions.assertEquals("|", s.get(1));
+        Assertions.assertEquals("2+5>7", s.get(2));
+        s = new LogicalExpressionParser("not important now", log).split("1+2+3<5||||    2+5>7");
+        Assertions.assertEquals(3, s.size());
+        Assertions.assertEquals("1+2+3<5", s.get(0));
+        Assertions.assertEquals("|", s.get(1));
+        Assertions.assertEquals("2+5>7", s.get(2));
+    }
+
+    @org.junit.jupiter.api.Test
+    void splitTest2() {
+        List<String> s;
+        s = new LogicalExpressionParser("not important now", log).split("1+2+3 < 5");
+        Assertions.assertEquals(1, s.size());
+        Assertions.assertEquals("1+2+3 < 5", s.get(0));
+        s = new LogicalExpressionParser("not important now", log).split("1+2+3<5 & 2+5>7 | 5<6");
+        Assertions.assertEquals(5, s.size());
+        Assertions.assertEquals("1+2+3<5", s.get(0));
+        Assertions.assertEquals("&", s.get(1));
+        Assertions.assertEquals("2+5>7", s.get(2));
+        Assertions.assertEquals("|", s.get(3));
+        Assertions.assertEquals("5<6", s.get(4));
+        s = new LogicalExpressionParser("not important now", log).split("1+2+3<5 & 2+5>7 & 5<6");
+        Assertions.assertEquals(5, s.size());
+        Assertions.assertEquals("1+2+3<5", s.get(0));
+        Assertions.assertEquals("&", s.get(1));
+        Assertions.assertEquals("2+5>7", s.get(2));
+        Assertions.assertEquals("&", s.get(3));
+        Assertions.assertEquals("5<6", s.get(4));
+        s = new LogicalExpressionParser("not important now", log).split("1+2+3<5 | 2+5>7 & 5<6");
+        Assertions.assertEquals(5, s.size());
+        Assertions.assertEquals("1+2+3<5", s.get(0));
+        Assertions.assertEquals("|", s.get(1));
+        Assertions.assertEquals("2+5>7", s.get(2));
+        Assertions.assertEquals("&", s.get(3));
+        Assertions.assertEquals("5<6", s.get(4));
+        s = new LogicalExpressionParser("not important now", log).split("1+2+3<5 | 2+5>7 | 5<6");
+        Assertions.assertEquals(5, s.size());
+        Assertions.assertEquals("1+2+3<5", s.get(0));
+        Assertions.assertEquals("|", s.get(1));
+        Assertions.assertEquals("2+5>7", s.get(2));
+        Assertions.assertEquals("|", s.get(3));
+        Assertions.assertEquals("5<6", s.get(4));
+        s = new LogicalExpressionParser("not important now", log).split("1+2+3<5    &&&&2+5>7 & 5<7 & 1+2+3<5||||    2+5>7");
+        Assertions.assertEquals(9, s.size());
+        Assertions.assertEquals("1+2+3<5", s.get(0));
+        Assertions.assertEquals("&", s.get(1));
+        Assertions.assertEquals("2+5>7", s.get(2));
+        Assertions.assertEquals("&", s.get(3));
+        Assertions.assertEquals("5<7", s.get(4));
+        Assertions.assertEquals("&", s.get(5));
+        Assertions.assertEquals("1+2+3<5", s.get(6));
+        Assertions.assertEquals("|", s.get(7));
+        Assertions.assertEquals("2+5>7", s.get(8));
+    }
+
+    @org.junit.jupiter.api.Test
+    void evalTest() {
+        LogicalExpressionParser comp;
+        comp = new LogicalExpressionParser("1+2+3 >= 7", log);
+        Assertions.assertFalse(comp.evaluate());
+        comp = new LogicalExpressionParser("1+2+3 >= 5", log);
+        Assertions.assertTrue(comp.evaluate());
+        comp = new LogicalExpressionParser("1+2+3 >= 7 | 1+2+3 >= 5", log);
+        Assertions.assertTrue(comp.evaluate());
+        comp = new LogicalExpressionParser("6 >= 7 & 6 >= 5", log);
+        Assertions.assertFalse(comp.evaluate());
+    }
+
+    @org.junit.jupiter.api.Test
+    void andTable() {
+        Assertions.assertTrue(new LogicalExpressionParser("true and true", log).evaluate());
+        Assertions.assertFalse(new LogicalExpressionParser("false and true", log).evaluate());
+        Assertions.assertFalse(new LogicalExpressionParser("false and false", log).evaluate());
+        Assertions.assertFalse(new LogicalExpressionParser("true and false", log).evaluate());
+        Assertions.assertTrue(new LogicalExpressionParser("true & true", log).evaluate());
+        Assertions.assertFalse(new LogicalExpressionParser("false && true", log).evaluate());
+        Assertions.assertFalse(new LogicalExpressionParser("false &&& false", log).evaluate());
+        Assertions.assertFalse(new LogicalExpressionParser("true &&&& false", log).evaluate());
+    }
+
+    @org.junit.jupiter.api.Test
+    void orTable() {
+        Assertions.assertTrue(new LogicalExpressionParser("true or true", log).evaluate());
+        Assertions.assertTrue(new LogicalExpressionParser("false or true", log).evaluate());
+        Assertions.assertFalse(new LogicalExpressionParser("false or false", log).evaluate());
+        Assertions.assertTrue(new LogicalExpressionParser("true or false", log).evaluate());
+        Assertions.assertTrue(new LogicalExpressionParser("true | true", log).evaluate());
+        Assertions.assertTrue(new LogicalExpressionParser("false || true", log).evaluate());
+        Assertions.assertFalse(new LogicalExpressionParser("false ||| false", log).evaluate());
+        Assertions.assertTrue(new LogicalExpressionParser("true |||| false", log).evaluate());
+    }
+
+    @org.junit.jupiter.api.Test
+    void xorTable() {
+        Assertions.assertFalse(new LogicalExpressionParser("true xor true", log).evaluate());
+        Assertions.assertTrue(new LogicalExpressionParser("false xor true", log).evaluate());
+        Assertions.assertFalse(new LogicalExpressionParser("false xor false", log).evaluate());
+        Assertions.assertTrue(new LogicalExpressionParser("true xor false", log).evaluate());
+    }
+
+    @org.junit.jupiter.api.Test
+    void eqTable() {
+        Assertions.assertTrue(new LogicalExpressionParser("true eq true", log).evaluate());
+        Assertions.assertFalse(new LogicalExpressionParser("false eq true", log).evaluate());
+        Assertions.assertTrue(new LogicalExpressionParser("false eq false", log).evaluate());
+        Assertions.assertFalse(new LogicalExpressionParser("true eq false", log).evaluate());
+    }
+
+    @org.junit.jupiter.api.Test
+    void implTable() {
+        Assertions.assertTrue(new LogicalExpressionParser("true imp true", log).evaluate());
+        Assertions.assertTrue(new LogicalExpressionParser("false imp true", log).evaluate());
+        Assertions.assertTrue(new LogicalExpressionParser("false imp false", log).evaluate());
+        Assertions.assertFalse(new LogicalExpressionParser("true imp false", log).evaluate());
+        Assertions.assertTrue(new LogicalExpressionParser("true impl true", log).evaluate());
+        Assertions.assertTrue(new LogicalExpressionParser("false impl true", log).evaluate());
+        Assertions.assertTrue(new LogicalExpressionParser("false impl false", log).evaluate());
+        Assertions.assertFalse(new LogicalExpressionParser("true impl false", log).evaluate());
+    }
+
+
+    @org.junit.jupiter.api.Test
+    void eqTableWithEq() {
+        Assertions.assertTrue(new LogicalExpressionParser("0 == 0  eq 0 == 0", log).evaluate());
+        Assertions.assertFalse(new LogicalExpressionParser("0 != 0 eq 0 == 0", log).evaluate());
+        Assertions.assertTrue(new LogicalExpressionParser("0 != 0  eq 0 != 0 ", log).evaluate());
+        Assertions.assertFalse(new LogicalExpressionParser("0 == 0  eq 0 != 0 ", log).evaluate());
+/**
+ * For a hwile, there were eq/neq and -eq/-neq operators
+ * But those colidate with logical eq and thus were removed
+ * workarounds to make avaiblable both were sucide
+ */
+        int ex = 0;
+        try {
+            new LogicalExpressionParser("0 -eq 0 eq 0 -eq 0", log).evaluate();
+        } catch (Exception e) {
+            ex++;
+        }
+        try {
+            new LogicalExpressionParser("0 -neq 0 eq 0 -eq 0", log).evaluate();
+        } catch (Exception e) {
+            ex++;
+        }
+        try {
+            new LogicalExpressionParser("0 neq 0  eq 0 neq 0 ", log).evaluate();
+        } catch (Exception e) {
+            ex++;
+        }
+        try {
+            new LogicalExpressionParser("0 eq 0  eq 0 neq 0 ", log).evaluate();
+        } catch (Exception e) {
+            ex++;
+        }
+        Assertions.assertEquals(4, ex, "four exceptions expected");
+    }
+
+}

--- a/src/test/java/parser/logical/LogicalExpressionParserTest.java
+++ b/src/test/java/parser/logical/LogicalExpressionParserTest.java
@@ -298,4 +298,11 @@ class LogicalExpressionParserTest {
         Assertions.assertEquals("true", exprPart.solve());
     }
 
+    @Test
+    void help() {
+        LogicalExpression exprPart = new LogicalExpression("help", log);
+        String h1 = exprPart.solve();
+        Assertions.assertTrue(h1.length() > 100);
+    }
+
 }

--- a/src/test/java/parser/logical/PrintingExpressionLogger.java
+++ b/src/test/java/parser/logical/PrintingExpressionLogger.java
@@ -1,0 +1,13 @@
+package parser.logical;
+
+public class PrintingExpressionLogger implements  ExpressionLogger {
+
+    private final boolean tests_verbose = true;
+
+    @Override
+    public void log(String s) {
+        if (tests_verbose) {
+            System.out.println(s);
+        }
+    }
+}


### PR DESCRIPTION
Hello!

I had spent quite a lot of time in July and August to fix/imprpove logical and comparing operations in ParserNG. At the end I found it as not possible, and TBH, I'm wondering how they are supposed to work, if they should.

I was in rush bit so I implemented wrapper around parserng in my main project ParserNG dependant (https://github.com/judovana/jenkins-report-generic-chart-column).
After another attempt to fix as it is done, I have decided to contribute the LogicalExpression parser on top of math parser to ParserNG it somehow belongs here...
Currently only numbers are supported for comparisons, although matrixes  should not be hard to added. It uses `[] `brackets so they are easily to be diverged from mathematical `()`. More then two operators must always use brackets. 

It think it would be better if this is part of parserng, then rotting in jenkins plugin alone. WDYT?

The MathExpression and main are utterly unspoiled by this. It is new, LogicalExpression class which must be used to reach the "new logical capabilities". Simialrly main uses MathExpression by default, and -l/-L must be passed to it to switch to logical expressions. As LogicalExpression should be forward comaptible with MathExpression, this is a bti disputable, and you may decide to change this in future (and use LogicalExpression by default and use MAthemtacial only when eg  -m/M is passed in to the main)
