### PR TITLE
Added basic tests for embedded sin and prod

### DIFF
--- a/src/test/java/parser/methods/ProdTest.java
+++ b/src/test/java/parser/methods/ProdTest.java
@@ -1,0 +1,75 @@
+package parser.methods;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import parser.MathExpression;
+
+public class ProdTest {
+
+    @Test
+    void prodAcceptsOnePlainArgument() {
+        MathExpression me;
+        me = new MathExpression("prod(5)");
+        Assertions.assertEquals("5.0", me.solve());
+    }
+
+    @Test
+    void prodAcceptsOnePlainExpression() {
+        MathExpression me;
+        me = new MathExpression("prod(5+5)");
+        Assertions.assertEquals("10.0", me.solve());
+    }
+
+
+    @Test
+    void prodAcceptsTwoPlainArguments() {
+        MathExpression me;
+        me = new MathExpression("prod(5,6)");
+        Assertions.assertEquals("30.0", me.solve());
+    }
+
+    @Test
+    void prodAcceptsTwoPlainExpressions() {
+        MathExpression me;
+        me = new MathExpression("prod(5+5, 4+4)");
+        Assertions.assertEquals("80.0", me.solve());
+    }
+
+    @Test
+    void prodAcceptsStatFunction() {
+        MathExpression me;
+        me = new MathExpression("prod(prod(5))");
+        Assertions.assertEquals("5.0", me.solve());
+    }
+
+    @Test
+    void prodAcceptsNumFunction() {
+        MathExpression me;
+        me = new MathExpression("prod(sin(5))");
+        Assertions.assertEquals("-0.9589242746631385", me.solve());
+    }
+
+    @Test
+    void prodAcceptsTwoStatFunction() {
+        MathExpression me;
+        me = new MathExpression("prod(prod(5),prod(6))");
+        Assertions.assertEquals("30.0", me.solve());
+    }
+
+    @Test
+    void prodAcceptsTwoNumFunction() {
+        MathExpression me;
+        me = new MathExpression("prod(sin(5),sin(5))");
+        Assertions.assertEquals("0.9195357645382262", me.solve());
+    }
+
+    @Test
+    void prodAcceptsStatAndNumFunction() {
+        MathExpression me;
+        me = new MathExpression("prod(prod(5),sin(5))");
+        Assertions.assertEquals("-4.794621373315692", me.solve());
+        me = new MathExpression("prod(sin(5),prod(5))");
+        Assertions.assertEquals("-4.794621373315692", me.solve());
+    }
+}

--- a/src/test/java/parser/methods/ext/SinTest.java
+++ b/src/test/java/parser/methods/ext/SinTest.java
@@ -1,0 +1,74 @@
+package parser.methods.ext;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import parser.MathExpression;
+
+public class SinTest {
+
+    @Test
+    void sinAcceptsOnePlainArgument() {
+        MathExpression me;
+        me = new MathExpression("sin(5)");
+        Assertions.assertEquals("-0.9589242746631385", me.solve());
+    }
+
+    @Test
+    void sinAcceptsOnePlainExpression() {
+        MathExpression me;
+        me = new MathExpression("sin(5+5)");
+        Assertions.assertEquals("-0.5440211108893698", me.solve());
+    }
+
+
+    @Test
+    void sinDontAcceptsTwoPlainArguments() {
+        MathExpression me;
+        me = new MathExpression("sin(5,6)");
+        Assertions.assertEquals("SYNTAX ERROR", me.solve());
+    }
+
+    @Test
+    void sinDontAcceptsTwoPlainExpressions() {
+        MathExpression me;
+        me = new MathExpression("sin(5+5, 4+4)");
+        Assertions.assertEquals("SYNTAX ERROR", me.solve());
+    }
+
+    @Test
+    void sinAcceptsStatFunction() {
+        MathExpression me;
+        me = new MathExpression("sin(sum(5))");
+        Assertions.assertEquals("-0.9589242746631385", me.solve());
+    }
+
+    @Test
+    void sinAcceptsNumFunction() {
+        MathExpression me;
+        me = new MathExpression("sin(sin(5))");
+        Assertions.assertEquals("-0.8185741444617193", me.solve());
+    }
+
+    @Test
+    void sinDontAcceptsTwoStatFunction() {
+        MathExpression me;
+        me = new MathExpression("sin(sum(5),sum(6))");
+        Assertions.assertEquals("SYNTAX ERROR", me.solve());
+    }
+
+    @Test
+    void sinDontAcceptsTwoNumFunction() {
+        MathExpression me;
+        me = new MathExpression("sin(sin(5),sin(5))");
+        Assertions.assertEquals("SYNTAX ERROR", me.solve());
+    }
+
+    @Test
+    void sinDontAcceptsStatAndNumFunction() {
+        MathExpression me;
+        me = new MathExpression("sin(sin(5),sum(5))");
+        Assertions.assertEquals("SYNTAX ERROR", me.solve());
+        me = new MathExpression("sin(sum(5),sin(5))");
+        Assertions.assertEquals("SYNTAX ERROR", me.solve());
+    }
+}


### PR DESCRIPTION
The fialures shows bug in parserng, where
a) single argument functions can accept multiple arguments, while pretending they are multiplied
b) multiple arguments functions are not able to accept single expression