### PR TITLE
Added Expanding parser, which can works above arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,12 +245,17 @@ The parser has its own set of built-in functions. They are:
     rng,mrng,rms,cov,min,max,s_d,variance,st_err,rnd,sort,plot,diff,intg,quad,t_root,
     root,linear_sys,det,invert,tri_mat,echelon,matrix_mul,matrix_div,matrix_add,matrix_sub,matrix_pow,transpose,matrix_edit
     
-  <br>
-  For runtime loaded list of all functions (with description, even in-runtime-added - see User hardcoded functions), run 'help' as MathExpression's value
+<br>
+For runtime loaded list of all functions (with description, even in-runtime-added - see User hardcoded functions), and environment variables, run <code>help</code> as MathExpression's value<br>
+
   ```
 MathExpression expression = new MathExpression("help");
 expression.solve();
   ``` 
+  
+##### Environment variables/java properties (so setup-able) in runtime).
+See <code>help</code> for actual version-specific, up-to date, list<br>
+<li> RADDEGDRAD_PNG - DEG/RAD/GRAD - allows to change units for trigonometric operations. Default is RAD. It is same as <code>MathExpression().setDRG(...)</code>
   <br>
 
 

--- a/src/main/java/logic/DRG_MODE.java
+++ b/src/main/java/logic/DRG_MODE.java
@@ -1,5 +1,9 @@
 package logic;
 
 public enum DRG_MODE {
+
     DEG, RAD, GRAD;
+
+    public static final String DEG_MODE_VARIABLE = "RADDEGDRAD_PNG";
+
 }

--- a/src/main/java/math/Main.java
+++ b/src/main/java/math/Main.java
@@ -6,10 +6,12 @@ import java.util.Arrays;
 import java.util.List;
 
 import interfaces.Solvable;
+import logic.DRG_MODE;
 import parser.LogicalExpression;
 import parser.MathExpression;
 import parser.cmd.ParserCmd;
 import parser.logical.ExpressionLogger;
+import parser.methods.Help;
 
 public class Main {
 
@@ -140,6 +142,7 @@ public class Main {
         System.out.println("  Without any parameter, input is considered as math expression and calculated");
         System.out.println("  without trim, it would be the same as launching " + MathExpression.class.getName() + " main class");
         System.out.println("  run help in verbose mode (" + helpSwitch.getSwitch(0) + " " + verboseSwitch.getSwitch(0) + ") to get examples");
+        System.out.println(Help.getEnvVariables());
     }
 
     static void examples() {

--- a/src/main/java/math/Main.java
+++ b/src/main/java/math/Main.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import interfaces.Solvable;
 import logic.DRG_MODE;
+import parser.ExpandingExpression;
 import parser.LogicalExpression;
 import parser.MathExpression;
 import parser.cmd.ParserCmd;
@@ -68,10 +69,12 @@ public class Main {
     private static final MultiSwitch helpSwitch = new MultiSwitch("-h", "-H", "--help");
     private static final MultiSwitch interactiveSwitch = new MultiSwitch("-i", "-I", "--interactive");
     private static final MultiSwitch logcalSwitch = new MultiSwitch("-l", "-L", "--logic");
+    private static final MultiSwitch expandableSwitch = new MultiSwitch("-e", "-E", "--expandable");
 
     private static boolean trim = false;
     private static boolean verbose = false;
     private static boolean logic = false;
+    private static boolean expandable = false;
 
     public static void main(String... args) throws IOException {
         List<String> aargs = new ArrayList<>(Arrays.asList(args));
@@ -87,6 +90,13 @@ public class Main {
         if (logcalSwitch.isContained(aargs)) {
             logic = true;
             logcalSwitch.removeFrom(aargs);
+        }
+        if (expandableSwitch.isContained(aargs)) {
+            expandable = true;
+            expandableSwitch.removeFrom(aargs);
+        }
+        if (isLogic() && isExpandable()) {
+            throw new RuntimeException("you have set both logical and expandable parser. that is no go. Use onoy one of them in time.");
         }
         if (helpSwitch.isContained(aargs)) {
             help();
@@ -109,7 +119,11 @@ public class Main {
                 }
                 String r = null;
                 try {
-                    Solvable exp = logic ? new LogicalExpression(ex, LogicalExpression.verboseStderrLogger) : new MathExpression(ex);
+                    Solvable exp = logic ?
+                            new LogicalExpression(ex, LogicalExpression.verboseStderrLogger) :
+                            expandable ?
+                                    new ExpandingExpression(ex, ExpandingExpression.getValuesFromVariables(), ExpandingExpression.verboseStderrLogger) :
+                                    new MathExpression(ex);
                     r  = exp.solve();
                 }catch(Exception fatal){
                     if (verbose){
@@ -130,6 +144,11 @@ public class Main {
         System.out.println(logcalSwitch + "        will add logical expression wrapper around the expression");
         System.out.println("                     Logical expression parser is much less evolved and slow. Do not use it if you don't must");
         System.out.println("                     If you use logical parse, result is always true/false. If it is not understood, it reuslts to false");
+        System.out.println(expandableSwitch + "  Will add expandable parser around logical expression to allow you to work with sets and views on those sets");
+        System.out.println("                     by "+ ExpandingExpression.VALUES_PNG + "/" + ExpandingExpression.VALUES_IPNG + "variables you can pass in the set of numbers");
+        System.out.println("                     and access them by L0,L1,,, L1.. ..L2  L3,..L5 notations (set is space delimited)");
+        System.out.println("                     you can calculate dynamic indexes by L{expression} and use MN variable which stores length of input set");
+        System.out.println("                     Expandable parser is not natural by CLI usage. using directly "+ExpandingExpression.class.getName() + " is better, but CLI is crucial for testing expressions");
         System.out.println(trimSwitch + "         by default, each line is one expression,");
         System.out.println("                     however for better redability, sometimes it is worthy to");
         System.out.println("                     to split the expression to multiple lines. and evaluate as one.");
@@ -184,7 +203,10 @@ public class Main {
         System.out.println("    true");
         System.out.println("  Note, that " + MathExpression.class.getName() + " nor " + LogicalExpression.class.getName() + " classes do not take any parameters except expressions");
         System.out.println("  Note, that " + ParserCmd.class.getName() + " class takes single parameter " + logcalSwitch + " to contorl its evaluation");
+        System.out.println("Logical extension:");
         System.out.println(new LogicalExpression(" 1 == 1", ExpressionLogger.DEV_NULL).getHelp());
+        System.out.println("Extandable extension:");
+        System.out.println(new ExpandingExpression(" 1 == 1", new ArrayList<String>(), ExpressionLogger.DEV_NULL).getHelp());
     }
 
     public static String joinArgs(List<String> filteredArgs, boolean trim) {
@@ -212,8 +234,16 @@ public class Main {
         return logic;
     }
 
+    public static boolean isExpandable() {
+        return expandable;
+    }
+
     public static void setLogic(boolean logic) {
         Main.logic = logic;
+    }
+
+    public static void setExpandable(boolean expandable) {
+        Main.expandable = expandable;
     }
 
     public static String getVersion() {
@@ -223,5 +253,9 @@ public class Main {
 
     public static MultiSwitch getLogcalSwitch() {
         return logcalSwitch;
+    }
+
+    public static MultiSwitch getExpandableSwitch() {
+        return expandableSwitch;
     }
 }

--- a/src/main/java/math/numericalmethods/FunctionExpander.java
+++ b/src/main/java/math/numericalmethods/FunctionExpander.java
@@ -186,7 +186,6 @@ public class FunctionExpander {
      */
     public Matrix getMatrix() {
         MathExpression fun = function.getMathExpression();
-        fun.setDRG(1);
         double dx = getXStep();
         double arr[][] = new double[degree + 1][degree + 2];
 
@@ -217,7 +216,6 @@ public class FunctionExpander {
      */
     public PrecisionMatrix getPrecisionMatrix() {
         MathExpression fun = function.getMathExpression();
-        fun.setDRG(1);
         double dx = getXStep();
         BigDecimal arr[][] = new BigDecimal[degree + 1][degree + 2];
 
@@ -513,7 +511,6 @@ public class FunctionExpander {
         String poly = expand.getPolynomial();
         System.out.println("polynomial function = " + poly + "\n\n\n");
         MathExpression me = new MathExpression(poly);
-        me.setDRG(1);
         me.setValue("x", "0.9999");
         System.out.println("evaluating polynomial function with normal parser = " + me.solve());
         expand.getFunction().getIndependentVariable("x").setValue("0.9999");

--- a/src/main/java/math/numericalmethods/NumericalDerivative.java
+++ b/src/main/java/math/numericalmethods/NumericalDerivative.java
@@ -86,7 +86,6 @@ public class NumericalDerivative {
         FunctionExpander expander = new FunctionExpander(xPoint-0.0001, xPoint+0.1, 20,FunctionExpander.DOUBLE_PRECISION, function );
         MathExpression polyDerivative = new MathExpression( expander.getPolynomialDerivative() );
 
-        polyDerivative.setDRG(1);
         String  variable = function.getIndependentVariables().get(0).getName();
         polyDerivative.setValue(variable, String.valueOf(xPoint) );
         return polyDerivative.solve();
@@ -102,7 +101,6 @@ public class NumericalDerivative {
      */
     public String findDerivativeByLimit(double dx){
         MathExpression func = function.getMathExpression();
-        func.setDRG(1);
         func.setValue(function.getIndependentVariables().get(0).getName(), String.valueOf(xPoint+dx));
         String upper = func.solve();
 

--- a/src/main/java/math/numericalmethods/NumericalIntegral.java
+++ b/src/main/java/math/numericalmethods/NumericalIntegral.java
@@ -180,7 +180,6 @@ public class NumericalIntegral {
         double m = 20000;
         double h = (xUpper - xLower)/( 2.0 * m );
         MathExpression fun = function.getMathExpression();
-        fun.setDRG(1);
         String variable = function.getIndependentVariables().get(0).getName();
 
 
@@ -241,7 +240,6 @@ public class NumericalIntegral {
 
 
         MathExpression fun = function.getMathExpression();
-        fun.setDRG(1);
         String variable = function.getIndependentVariables().get(0).getName();
 
 
@@ -334,7 +332,6 @@ public class NumericalIntegral {
     public String findTrapezoidalIntegral(){
         double dx = (xUpper - xLower)/( 10000.0 );
         MathExpression fun = function.getMathExpression();
-        fun.setDRG(1);
         String variable = function.getIndependentVariables().get(0).getName();
         fun.setValue(variable, String.valueOf(xLower));
 
@@ -382,7 +379,6 @@ public class NumericalIntegral {
 
 
         MathExpression fun = function.getMathExpression();
-        fun.setDRG(1);
         String variable = function.getIndependentVariables().get(0).getName();
         fun.setValue(variable, String.valueOf(xLower));
 
@@ -638,7 +634,6 @@ public class NumericalIntegral {
 
 
         MathExpression fun = new MathExpression( function.getMathExpression().getExpression() );
-        fun.setDRG(1);
         String variable = function.getIndependentVariables().get(0).getName();
 
 

--- a/src/main/java/math/numericalmethods/RootFinder.java
+++ b/src/main/java/math/numericalmethods/RootFinder.java
@@ -530,9 +530,6 @@ public class RootFinder {
             Function gradFunc = new Function("@("+variable+")"+gradFunxn);
             //System.err.println("gradient function is "+gradFunc.expressionForm());
 
-            function.getMathExpression().setDRG(1);
-            gradFunc.getMathExpression().setDRG(1);
-
             function.getMathExpression().setValue(variable, String.valueOf(xOne));
             double f_x = Double.parseDouble(  function.eval() );
 
@@ -597,7 +594,6 @@ public class RootFinder {
 
             String variable = getVariable();
 
-            function.getMathExpression().setDRG(1);
             function.getMathExpression().setValue(variable, String.valueOf(xOne));
             System.err.println("xOne = "+xOne+", expression: "+function.getMathExpression().getExpression());
             double f1 = Double.parseDouble(  function.eval() );

--- a/src/main/java/math/otherBaseParser/BaseNFunction.java
+++ b/src/main/java/math/otherBaseParser/BaseNFunction.java
@@ -44,7 +44,6 @@ public class BaseNFunction extends MathExpression {
     public BaseNFunction( String input,int baseOfOperation ) {
         super(input);
         this.baseOfOperation=baseOfOperation;
-        setDRG(1);
 
         convertNumbersToDecimal();
     }

--- a/src/main/java/parser/ExpandingExpression.java
+++ b/src/main/java/parser/ExpandingExpression.java
@@ -1,0 +1,125 @@
+package parser;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import interfaces.Solvable;
+import math.Main;
+import parser.expanding.ExpandingExpressionParser;
+import parser.logical.ComparingExpressionParser;
+import parser.logical.ExpressionLogger;
+import parser.logical.LogicalExpressionMemberFactory;
+import parser.methods.Declarations;
+
+public class ExpandingExpression implements Solvable {
+
+    private final String originalExpression;
+    private final List<String> points;
+    private final ExpressionLogger mainLogger;
+    private final LogicalExpressionMemberFactory logicalExpressionMemberFactory;
+    public static final String VALUES_PNG = "VALUES_PNG";
+    public static final String VALUES_IPNG = "VALUES_IPNG";
+
+    public static final ExpressionLogger verboseStderrLogger = new ExpressionLogger() {
+        @Override
+        public void log(String s) {
+            if (Main.isVerbose()) {
+                System.err.println(s);
+            }
+        }
+    };
+
+    public ExpandingExpression(String s, List<String> points, ExpressionLogger logger) {
+        this(s, points, logger, new ComparingExpressionParser.ComparingExpressionParserFactory());
+    }
+
+    public ExpandingExpression(String s, List<String> points, ExpressionLogger logger, LogicalExpressionMemberFactory logicalExpressionMemberFactory) {
+        this.originalExpression = s;
+        this.mainLogger = logger;
+        this.points = points;
+        this.logicalExpressionMemberFactory = logicalExpressionMemberFactory;
+    }
+
+    public static void main(String args[]) {
+        String in = Main.joinArgs(Arrays.asList(args), true);
+        verboseStderrLogger.log(in);
+        if (in.trim().equalsIgnoreCase(Declarations.HELP)) {
+            System.out.println(getHelp());
+            return;
+        }
+        List<String> values = getValuesFromVariables();
+        System.out.println(new ExpandingExpression(in, values, verboseStderrLogger).solve());
+    }//end method
+
+    public static List<String> getValuesFromVariables() {
+        String values_png = System.getenv(VALUES_PNG);
+        String values_ipng = System.getenv(VALUES_IPNG);
+        if (values_png != null && values_ipng != null) {
+            throw new RuntimeException("Both " + VALUES_PNG + " and " + VALUES_IPNG + " are declared. That is no go");
+        }
+        List<String> values;
+        if (values_png != null) {
+            if (values_png.trim().isEmpty()) {
+                values = new ArrayList<>();
+            } else {
+                values = new ArrayList<>(Arrays.asList(values_png.split("\\s+")));
+                Collections.reverse(values);
+            }
+        } else if (values_ipng != null) {
+            if (values_ipng.trim().isEmpty()) {
+                values = new ArrayList<>();
+            } else {
+                values = new ArrayList<>(Arrays.asList(values_ipng.split("\\s+")));
+            }
+        } else {
+            throw new RuntimeException("None of " + VALUES_PNG + " or " + VALUES_IPNG + " declared. Try help");
+        }
+        if (values.isEmpty()) {
+            verboseStderrLogger.log("Warning, " + VALUES_PNG + " or " + VALUES_IPNG + " declared, but are empty!");
+        }
+        return values;
+    }
+
+    @Override
+    public String solve() {
+        if (originalExpression.trim().equalsIgnoreCase(Declarations.HELP)) {
+            return getHelp();
+        }
+        ExpandingExpressionParser eep = new ExpandingExpressionParser(originalExpression, points, mainLogger,  logicalExpressionMemberFactory);
+        mainLogger.log(eep.getExpanded());
+        String r = eep.solve();
+        return r;
+    }
+
+
+    public static String getHelp() {
+        //longterm todo, repalce this static help by better help using delegated help methods from logical parser
+        return "This is abstraction which allows to set with slices, rows and subset of immutable known numbers." + "\n" +
+                "Instead of numbers, you can use literalls L0, L1...L99, which you can then call by:" + "\n" +
+                "Ln - vlaue of Nth number" + "\n" +
+                "L2..L4 - will expand to values of L2,L3,L4 - order is hnoured" + "\n" +
+                "L2.. - will expand to values of L2,L3,..Ln-1,Ln" + "\n" +
+                "..L5 - will expand to values of  L0,L1...L4,L5" + "\n" +
+                "When used as standalone, " + VALUES_PNG + " xor " + VALUES_IPNG + "  are used to pass in the space separated numbers (the I is inverted order)" + "\n" +
+                "Assume " + VALUES_PNG + "='5 9 3 8', then it is the same as " + VALUES_IPNG + "='8 3 9 5'; BUt be aware, with I the L.. and ..L are a bit oposite then expected" + "\n" +
+                "L0 then expand to 8; L2.. expands to 9,3,8; ' ..L2 expands to 5,9 " + "\n" +
+                "L2..L4 expands to 9,5; L4..L2 expands to 5,9" + "\n" +
+                "There is a special element MN, which represents count of input points, so you do not need to call `count(..L0)` arround and arround. So..." + "\n" +
+                "Expression : avg(..L1)*1.1-MN <  L0 | L1*1.3 + MN<  L0 \n" +
+                "Upon       : 60,20,80,70\n" +
+                "As         : Ln...L1,L0\n" +
+                "MN         = 4\n" +
+                "Expanded as: avg(60,20,80)*1.1-4 <  70 | 80*1.3 + 4<  70\n" +
+                "...indeed\n" +
+                "Dynamic calculation of L's indexes\n" +
+                "Sometimes, Lx, as number is not enough, and you need to calcualte it dynamically. To do so, you can use L{}\n" +
+                "Inisde {} can be mathematical formula (including Ls, MN. or even nested {}, which will evaluate itself as number, which will be used as Lx. Eg:\n" +
+                "'avg(..L{MN/2}) < avg(L{MN/2}..)' will go to 'avg(..L1) < avg(L1..)' will go on 1 2 3 to 'avg(1,2 ) < avg(2,3) will go to 1.5<2.5 ... true'\n" +
+                "For fun try eg: VALUES_PNG='1 2 3' on 'avg(..L{L{MN/2}}) < avg(L{L{MN/2}}..)'\n" +
+                "This parser by default uses LogicalExpression interpreter, but should work directly in" + "\n" +
+                "In verbose mode, the expanded expression is always printed";
+
+    }
+}

--- a/src/main/java/parser/Function.java
+++ b/src/main/java/parser/Function.java
@@ -789,7 +789,6 @@ public class Function implements Savable {
         int i = 0;
         for (double x = xLower; i < len && x <= xUpper; x += xStep, i++) {
             mathExpression.setValue(variableName, String.valueOf(x));
-            mathExpression.setDRG(DRG);
             results[0][i] = Double.parseDouble(mathExpression.solve());
             results[1][i] = x;
         }//end for
@@ -817,7 +816,6 @@ public class Function implements Savable {
      * variables and constants.
      */
     public String eval() {
-        mathExpression.setDRG(1);
         return mathExpression.solve();
     }
 

--- a/src/main/java/parser/MathExpression.java
+++ b/src/main/java/parser/MathExpression.java
@@ -6,6 +6,7 @@ package parser;
 
 import interfaces.Savable;
 import interfaces.Solvable;
+import logic.DRG_MODE;
 import math.Main;
 import parser.methods.Declarations;
 import parser.methods.Help;
@@ -63,7 +64,7 @@ public class MathExpression implements Savable, Solvable {
     public Parser_Result parser_Result = Parser_Result.VALID;
     //determines the mode in which trig operations will be carried out on numbers.if DRG==0,it is done in degrees
 //if DRG==1, it is done in radians and if it is 2, it is done in grads.
-    protected int DRG = 1;
+    private DRG_MODE DRG = Declarations.degGradRadFromVariable();
     public static String lastResult = "0.0";
     private ArrayList<String> whitespaceremover = new ArrayList<>();//used to remove white spaces from the ArrayList
     /**
@@ -257,7 +258,7 @@ public class MathExpression implements Savable, Solvable {
      *
      * @return the DRG value:0 for degrees, 1 for rads, 2 for grads
      */
-    public int getDRG() {
+    public DRG_MODE getDRG() {
         return DRG;
     }
 
@@ -266,8 +267,8 @@ public class MathExpression implements Savable, Solvable {
      *
      * @param DRG
      */
-    public void setDRG(int DRG) {
-        this.DRG = (DRG == 0 || DRG == 1 || DRG == 2) ? DRG : 0;
+    public void setDRG(DRG_MODE DRG) {
+        this.DRG = DRG;
     }
 
     /**

--- a/src/main/java/parser/MathScanner.java
+++ b/src/main/java/parser/MathScanner.java
@@ -13,6 +13,7 @@ package parser;
  */
 //sin2+cos3-9tan(A+3B)
 //[sin,2,+,cos,3,-,9,tan (,A,+,3,B,)]
+import parser.methods.Declarations;
 import parser.methods.Method;
 
 import math.numericalmethods.RootFinder;
@@ -1276,10 +1277,10 @@ public class MathScanner {
             if (sz == 4 || sz == 5) {
                 if (Method.isMatrixMethod(list.get(0)) && isOpeningBracket(list.get(1)) && Method.isUserDefinedFunction(list.get(2))) {
                     if (sz == 4 && isClosingBracket(list.get(3))) {
-                        Method.run(list, 1);
+                        Method.run(list, Declarations.degGradRadFromVariable());
                     } else if (sz == 5 && (Method.isUserDefinedFunction(list.get(3)) || isNumber(list.get(3)) || isVariableString(list.get(3))) && isClosingBracket(list.get(4))) {
                         System.out.println("Debug--4");
-                        Method.run(list, 1);
+                        Method.run(list, Declarations.degGradRadFromVariable());
                     }
 
                 }

--- a/src/main/java/parser/cmd/ParserCmd.java
+++ b/src/main/java/parser/cmd/ParserCmd.java
@@ -13,8 +13,10 @@ import java.util.List;
 
 import interfaces.Solvable;
 import math.Main;
+import parser.ExpandingExpression;
 import parser.LogicalExpression;
 import parser.MathExpression;
+import parser.logical.ExpressionLogger;
 
 /**
  * @author GBEMIRO JIBOYE <gbenroscience@gmail.com>
@@ -28,6 +30,9 @@ public class ParserCmd {
         if (args.length > 0) {
             if (Main.getLogcalSwitch().isIn(args[0])) {
                 Main.setLogic(true);
+            }
+            if (Main.getExpandableSwitch().isIn(args[0])) {
+                Main.setExpandable(true);
             }
         }
         BufferedReader sc = new BufferedReader(new InputStreamReader(System.in));
@@ -66,7 +71,12 @@ public class ParserCmd {
     private static void calWitOutput(String cmd) {
         String ans = null;
         try {
-            Solvable expression = Main.isLogic() ? new LogicalExpression(cmd, LogicalExpression.verboseStderrLogger) : new MathExpression(cmd);
+
+            Solvable expression = Main.isLogic() ?
+                    new LogicalExpression(cmd, LogicalExpression.verboseStderrLogger) :
+                    Main.isExpandable() ?
+                            new ExpandingExpression(cmd, ExpandingExpression.getValuesFromVariables(), ExpandingExpression.verboseStderrLogger) :
+                            new MathExpression(cmd);
             ans = expression.solve();
         }catch (Exception ex) {
             ans = ex.getMessage();

--- a/src/main/java/parser/expanding/ExpandingExpressionParser.java
+++ b/src/main/java/parser/expanding/ExpandingExpressionParser.java
@@ -1,0 +1,236 @@
+package parser.expanding;
+
+import parser.LogicalExpression;
+import parser.logical.ComparingExpressionParser;
+import parser.logical.ExpressionLogger;
+import parser.logical.LogicalExpressionMemberFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class  ExpandingExpressionParser {
+
+    private static final int MAX = 100;
+    private static final Pattern downRange = Pattern.compile("\\.\\.L\\d+");
+    private static final Pattern upRange = Pattern.compile("L\\d+\\.\\.");
+    private static final Pattern bothRange = Pattern.compile("L\\d+\\.\\.L\\d+");
+    private final String originalExpression;
+    private final List<String> points;
+    private final LogicalExpression logicalExpressionParser;
+    private final LogicalExpressionMemberFactory logicalExpressionMemberFactory;
+    private final ExpressionLogger log;
+    private final String expanded;
+
+    public ExpandingExpressionParser(String expression, List<String> points, ExpressionLogger log) {
+        this(expression, points, log, true, new ComparingExpressionParser.ComparingExpressionParserFactory());
+    }
+
+    public ExpandingExpressionParser(String expression, List<String> points, ExpressionLogger log, LogicalExpressionMemberFactory logicalExpressionMemberFactory) {
+        this(expression, points, log, true, logicalExpressionMemberFactory);
+    }
+
+    private ExpandingExpressionParser(String expression, List<String> points, ExpressionLogger log, boolean details, LogicalExpressionMemberFactory logicalExpressionMemberFactory) {
+        this.log = log;
+        this.points = points;
+        this.originalExpression = expression;
+        this.logicalExpressionMemberFactory = logicalExpressionMemberFactory;
+        log.log("Expression : " + originalExpression.replaceAll("\\s*L\\s*", "L"));
+        List<String> naturalisedOrder = new ArrayList<>(points);
+        Collections.reverse(naturalisedOrder);
+        if (details) {
+            log.log("Upon       : " + naturalisedOrder.stream().collect(Collectors.joining(",")));
+            log.log("As         : Ln...L1,L0");
+            log.log("MN         = " + points.size());
+        }
+        expanded = expandALL(expression);
+        log.log("Expanded as: " + expanded);
+        logicalExpressionParser = new LogicalExpression(expanded, new ExpressionLogger.InheritingExpressionLogger(log), logicalExpressionMemberFactory);
+    }
+
+    String expandALL(String expression) {
+        //order metters!
+        String expanded = expression;
+        expanded = expandMN(expression);
+        expanded = expandCurlyIndexes(expanded);
+        expanded = expanded.replaceAll("L\\s*", "L");
+        expanded = expanded.replaceAll("\\s*\\.\\.\\s*", "..");
+        expanded = expandLL(expanded);
+        expanded = expandLd(expanded);
+        expanded = expandLu(expanded);
+        if (points.size() > 0) {
+            //maybe better to throw and die?
+            expanded = expandL(expanded);
+        } else {
+            log.log("Warning! no points in input!");
+        }
+        return expanded;
+    }
+
+    String expandCurlyIndexes(String expression) {
+        return evalBrackets(expression, new ExpressionLogger.InheritingExpressionLogger(log), new int[]{0});
+    }
+
+    String expandMN(String expression) {
+        return expression.replace("MN", "" + points.size());
+    }
+
+    String expandLL(String expression) {
+        while (true) {
+            Matcher m = bothRange.matcher(expression);
+            boolean found = m.find();
+            if (!found) {
+                break;
+            }
+            String group = m.group();
+            expression = expression.replace(group, createRange(group.replace("L", "").replaceAll("\\.\\..*", ""), group.replace("L", "").replaceAll(".*\\.\\.", "")));
+        }
+        return expression;
+    }
+
+    String expandLd(String expression) {
+        while (true) {
+            Matcher m = downRange.matcher(expression);
+            boolean found = m.find();
+            if (!found) {
+                break;
+            }
+            String group = m.group();
+            expression = expression.replace(group, createRange((points.size() - 1) + "", group.replace("..L", "")));
+        }
+        return expression;
+    }
+
+    String expandLu(String expression) {
+        while (true) {
+            Matcher m = upRange.matcher(expression);
+            boolean found = m.find();
+            if (!found) {
+                break;
+            }
+            String group = m.group();
+            expression = expression.replace(group, createRange(group.replace("L", "").replaceAll("\\.\\..*", ""), "0"));
+        }
+        return expression;
+    }
+
+    String expandL(String expression) {
+        for (int x = Math.min(9, MAX); x >= 0; x--) {
+            expression = expression.replace("L0" + x, points.get(limit(x)));
+        }
+        for (int x = MAX; x >= 0; x--) {
+            expression = expression.replace("L" + x, points.get(limit(x)));
+        }
+        return expression;
+    }
+
+    private String createRange(String from, String to) {
+        return createRange(Integer.parseInt(from), Integer.parseInt(to));
+    }
+
+    private String createRange(int from, int to) {
+        from = limit(from);
+        to = limit(to);
+        int ffrom = Math.min(from, to);
+        boolean revert = false;
+        if (ffrom != from) {
+            revert = true;
+        }
+        int tto = Math.max(from, to);
+        if (tto >= points.size()) {
+            tto = points.size() - 1;
+        }
+        List<String> l = new ArrayList(tto - ffrom + 5);
+        for (int i = ffrom; i <= tto; i++) {
+            l.add(points.get(i));
+        }
+        if (revert) {
+            Collections.reverse(l);
+        }
+        return l.stream().collect(Collectors.joining(","));
+    }
+
+    private int limit(int i) {
+        if (i < 0) {
+            return 0;
+        }
+        if (i >= points.size()) {
+            return points.size() - 1;
+        }
+        return i;
+    }
+
+    public String solve() {
+        String rs = logicalExpressionParser.solve();
+        log.log("is: " + rs);
+        return rs;
+    }
+
+    public boolean evaluate() {
+        Boolean r = Boolean.parseBoolean(solve());
+        return r;
+    }
+
+    public String getExpanded() {
+        return expanded;
+    }
+
+
+    private String evalBrackets(String ex, ExpressionLogger logger, int[] depth) {
+        depth[0] = depth[0] + 1;
+        if (ex.contains("{")) {
+            logger.log("L indexes brackets: " + ex);
+        }
+        for (int x = 0; x < ex.length(); x++) {
+            if (ex.charAt(x) == '{') {
+                for (int z = x - 1; z >= 0; z--) {
+                    if (ex.charAt(z) != ' ' && ex.charAt(z) != '\n' && ex.charAt(z) != '\t') {
+                        break;
+                    }
+                }
+                int c = 1;
+                for (int y = x + 1; y < ex.length(); y++) {
+                    if (ex.charAt(y) == '{') {
+                        c++;
+                    }
+                    if (ex.charAt(y) == '}') {
+                        c--;
+                        if (c == 0) {
+                            String s = ex.substring(x + 1, y);
+                            String eval = null;
+                            if (s.contains("}")) {
+                                eval = evalBrackets(s, new ExpressionLogger.InheritingExpressionLogger(logger), depth);
+                            } else {
+                                eval = evalDirect(s, new ExpressionLogger.InheritingExpressionLogger(logger));
+                            }
+                            String s1 = ex.substring(0, x);
+                            String s2 = ex.substring(y + 1);
+                            ex = s1 + " " + eval + " " + s2;
+                            logger.log("to: " + ex);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        depth[0] = depth[0] - 1;
+        if (depth[0] > 0) {
+            String r = evalDirect(ex, new ExpressionLogger.InheritingExpressionLogger(logger));
+            return r;
+        } else {
+            return ex;
+        }
+
+    }
+
+    private String evalDirect(String s, ExpressionLogger logger) {
+        ExpandingExpressionParser lex = new ExpandingExpressionParser(s, points, logger, false, logicalExpressionMemberFactory);
+        String r = lex.solve();
+        int rr = new Double(r).intValue();//L2.0 is not valid value, but L2 is
+        logger.log(s + " = " + rr + " (" + r + ")");
+        return "" + rr;
+    }
+}

--- a/src/main/java/parser/methods/Declarations.java
+++ b/src/main/java/parser/methods/Declarations.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import logic.DRG_MODE;
 import parser.TYPE;
 import parser.methods.ext.Avg;
 import parser.methods.ext.Abs;
@@ -411,5 +412,24 @@ public class Declarations {
             }
         }
         return false;
+    }
+
+    public static DRG_MODE degGradRadFromVariable() {
+        String userDrgMode = System.getenv(DRG_MODE.DEG_MODE_VARIABLE);
+        if (userDrgMode == null) {
+            userDrgMode = System.getProperty(DRG_MODE.DEG_MODE_VARIABLE);
+        }
+        if (userDrgMode == null) {
+            return DRG_MODE.RAD;
+        }
+        if (userDrgMode.toUpperCase().trim().equals("DEG")) {
+            return DRG_MODE.DEG;
+        } else if (userDrgMode.toUpperCase().trim().equals("RAD")) {
+            return DRG_MODE.RAD;
+        } if (userDrgMode.toUpperCase().trim().equals("GRAD")) {
+            return DRG_MODE.GRAD;
+        } else {
+            return DRG_MODE.RAD;
+        }
     }
 }

--- a/src/main/java/parser/methods/Help.java
+++ b/src/main/java/parser/methods/Help.java
@@ -1,5 +1,7 @@
 package parser.methods;
 
+import logic.DRG_MODE;
+
 import static  parser.methods.Declarations.*;
 
 public class Help {
@@ -12,9 +14,14 @@ public class Help {
             sb.append(getHelp(op)).append("\n");
         }
         sb.append("List of functions is just tip of iceberg, see: https://github.com/gbenroscience/ParserNG for all features").append("\n");
+        sb.append(getEnvVariables()).append("\n");
         return sb.toString();
     }
 
+    public static String getEnvVariables() {
+        return "  Environment variables/java properties (so setup-able) in runtime):\n" +
+               "        " + DRG_MODE.DEG_MODE_VARIABLE + " - DEG/RAD/GRAD - allows to change units for trigonometric operations. Default is RAD. It is same as MathExpression().setDRG(...)";
+    }
     public static String getHelp(String op) {
         for(BasicNumericalMethod basicNumericalMethod: Declarations.getBasicNumericalMethods()){
             if (op.equals(basicNumericalMethod.getName())){

--- a/src/main/java/parser/methods/Help.java
+++ b/src/main/java/parser/methods/Help.java
@@ -1,6 +1,7 @@
 package parser.methods;
 
 import logic.DRG_MODE;
+import parser.ExpandingExpression;
 
 import static  parser.methods.Declarations.*;
 
@@ -20,7 +21,8 @@ public class Help {
 
     public static String getEnvVariables() {
         return "  Environment variables/java properties (so setup-able) in runtime):\n" +
-               "        " + DRG_MODE.DEG_MODE_VARIABLE + " - DEG/RAD/GRAD - allows to change units for trigonometric operations. Default is RAD. It is same as MathExpression().setDRG(...)";
+               "        " + DRG_MODE.DEG_MODE_VARIABLE + " - DEG/RAD/GRAD - allows to change units for trigonometric operations. Default is RAD. It is same as MathExpression().setDRG(...)\n" +
+               "        " + ExpandingExpression.VALUES_PNG + "/" + ExpandingExpression.VALUES_IPNG + " - space separated numbers - allows to set numboers for " + ExpandingExpression.class.getName();
     }
     public static String getHelp(String op) {
         for(BasicNumericalMethod basicNumericalMethod: Declarations.getBasicNumericalMethods()){

--- a/src/main/java/parser/methods/Method.java
+++ b/src/main/java/parser/methods/Method.java
@@ -4,6 +4,7 @@
  */
 package parser.methods;
 
+import logic.DRG_MODE;
 import parser.CustomScanner;
 import parser.Function;
 import static parser.STRING.*;
@@ -413,7 +414,7 @@ public class Method {
      * @return a {@link List} object which is the output of the method's
      * operation.
      */
-    public static List<String> run(List<String> list, int DRG) {
+    public static List<String> run(List<String> list, DRG_MODE DRG) {
         
         quickFixCompoundStructuresInStatsExpression(list);
         String name = list.get(0);
@@ -427,6 +428,8 @@ public class Method {
             for (BasicNumericalMethod basicNumericalMethod: getBasicNumericalMethods()){
                 if (name.equals(basicNumericalMethod.getName())){
                     Set set = new Set(list);
+                    //TODO, make basicNumericalMethod statefull (initialize by reflection)
+                    //basicNumericalMethod.setRadDegGrad(DRG);
                     result = basicNumericalMethod.solve(new ArrayList<>(set.getData()));
                     list.clear();
                     list.add(result);
@@ -729,7 +732,7 @@ public class Method {
             if (sz == 1) {
                 try {
                     if (!list.get(0).equals("Infinity") && isNumber(list.get(0))) {
-                        if (DRG == 0) {
+                        if (DRG == DRG_MODE.DEG) {
                             if (name.equals(SIN)) {
                                 result = String.valueOf(Maths.sinDegToRad(Double.valueOf(list.get(0))));
                             } else if (name.equals(SINH)) {
@@ -809,8 +812,7 @@ public class Method {
 
 //add more definitions below....
                         }//end if DRG == 0
-                        else if (DRG == 1) {
-
+                        else if (DRG == DRG_MODE.RAD) {
                             if (name.equals(SIN)) {
                                 result = String.valueOf(Math.sin(Double.valueOf(list.get(0))));
                             } else if (name.equals(SINH)) {
@@ -890,8 +892,7 @@ public class Method {
 
 //add more definitions below....
                         }//end else if DRG == 1
-                        else if (DRG == 2) {
-
+                        else if (DRG == DRG_MODE.GRAD) {
                             if (name.equals(SIN)) {
                                 result = String.valueOf(Maths.sinGradToRad(Double.valueOf(list.get(0))));
                             } else if (name.equals(SINH)) {

--- a/src/main/java/util/MathExpressionManager.java
+++ b/src/main/java/util/MathExpressionManager.java
@@ -34,12 +34,6 @@ public class MathExpressionManager {
      * of this class use to optimize an evaluation of an expression.
      */
     private int maxSize=200;
-    /**
-     * Whether to compute trigonometric functions
-     * in degrees, rads or grads. Set to 0 for degrees, set to 1 for rads
-     * and set to 2 for grads.
-     */
-    private int drgStatus=1;
 
 
     public MathExpressionManager() {
@@ -71,16 +65,6 @@ public class MathExpressionManager {
         this.maxSize = maxSize;
     }
 
-    public void setDrgStatus(int drgStatus) {
-        this.drgStatus = drgStatus>=0&&drgStatus<3?drgStatus:1;
-        for(int i=0;i<functions.size();i++){
-            functions.get(i).setDRG(drgStatus);
-        }
-    }//end method
-
-    public int getDrgStatus() {
-        return drgStatus;
-    }
 
     /**
      * A workspace uses a MathExpressionManager to
@@ -251,7 +235,6 @@ public class MathExpressionManager {
      */
     public MathExpression createFunction( String expr ){
         MathExpression f = new MathExpression(expr);
-        f.setDRG(1);
         storeFunction( f );
         return f;
     }//end method createFunction
@@ -292,7 +275,6 @@ public class MathExpressionManager {
 
             if (mathExpr!=null && !mathExpr.isEmpty() && exprCount == 1) {
                 if ((f = getFunctionByExpression(mathExpr)) != null) {//optimize function
-                    f.setDRG(drgStatus);
                 }//end if
                 else {
 /**
@@ -301,7 +283,6 @@ public class MathExpressionManager {
  * constants in the constructor
  */
                     f = new MathExpression("("+mathExpr+")");
-                    f.setDRG(drgStatus);
                     storeFunction(f);
                 }//end else
 

--- a/src/main/java/util/VariableManager.java
+++ b/src/main/java/util/VariableManager.java
@@ -396,7 +396,6 @@ public class VariableManager {
         private String getValue(String expr) throws NullPointerException, InputMismatchException {
             MathExpression func = new MathExpression(expr);
             func.setVariableValuesInFunction(func.getScanner());
-            func.setDRG(1);
             return func.solve();
         }
 

--- a/src/test/java/parser/expanding/ExpandingExpressionParserTest.java
+++ b/src/test/java/parser/expanding/ExpandingExpressionParserTest.java
@@ -1,0 +1,163 @@
+package parser.expanding;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import parser.logical.PrintingExpressionLogger;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Nit for REVERT
+ * The poins in the chart, are ordered as
+ * Ln Ln-1 ...L4 L3 L2 L1 L0
+ * Unluckily lists and arrays are creating structures indexed as 0,1,2,3,...n-1,n
+ * Which is surprisingly hard to keep rotating in mind
+ *
+ * So each input array is comming in declared as 0,1,2...N and then it is reverted before passing in,
+ * so it behaves naturaly  - we see it as real N .. 1,0  and parser is reading it as declared before revert, thuis 0,1..N
+ *
+ */
+class ExpandingExpressionParserTest {
+
+    private static PrintingExpressionLogger log = new PrintingExpressionLogger();
+
+    @org.junit.jupiter.api.Test
+    void expandAll() {
+        String s = "avg(..L1)*1.1 <  L0 | L1*1.3 <  L0 ";
+        ExpandingExpressionParser comp = new ExpandingExpressionParser(s, revert(Arrays.asList("60", "20", "80", "70")), log);
+        String r = comp.getExpanded();
+        Assertions.assertEquals("avg(60,20,80)*1.1 <  70 | 80*1.3 <  70 ", r);
+        Assertions.assertTrue(comp.evaluate());
+    }
+
+    @org.junit.jupiter.api.Test
+    void expandAMN() {
+        String s = "avg(..L1)*1.1-MN <  L0 | L1*1.3 + MN<  L0 ";
+        ExpandingExpressionParser comp = new ExpandingExpressionParser(s, revert(Arrays.asList("60", "20", "80", "70")), log);
+        String r = comp.getExpanded();
+        Assertions.assertEquals("avg(60,20,80)*1.1-4 <  70 | 80*1.3 + 4<  70 ", r);
+        Assertions.assertTrue(comp.evaluate());
+
+    }
+
+    @org.junit.jupiter.api.Test
+    void expandLLsTest() {
+        String s;
+        s = new ExpandingExpressionParser("not important now", revert(Arrays.asList("1", "2", "3")), log).expandLL("L1..L2");
+        Assertions.assertEquals("2,1", s);
+        s = new ExpandingExpressionParser("not important now", revert(Arrays.asList("1", "2", "3")), log).expandLL("L2..L1");
+        Assertions.assertEquals("1,2", s);
+        s = new ExpandingExpressionParser("not important now", revert(Arrays.asList("1", "2", "3")), log).expandLL("L0..L0");
+        Assertions.assertEquals("3", s);
+        s = new ExpandingExpressionParser("not important now", revert(Arrays.asList("1", "2", "3")), log).expandLL("L1..L125");
+        Assertions.assertEquals("2,1", s);
+        s = new ExpandingExpressionParser("not important now", revert(Arrays.asList("1", "2", "3")), log).expandLL("L123..L125");
+        Assertions.assertEquals("1", s);
+        s = new ExpandingExpressionParser("not important now", revert(Arrays.asList("1", "2", "3")), log).expandLL("L5 L0..L3  L1   L3..L0  L2 L2..L2 L1..L1");
+        Assertions.assertEquals("L5 3,2,1  L1   1,2,3  L2 1 2", s);
+    }
+
+
+    @org.junit.jupiter.api.Test
+    void expandLdTest() {
+        String s;
+        s = new ExpandingExpressionParser("not important now", revert(Arrays.asList("1", "2", "3")), log).expandLd("..L5");
+        Assertions.assertEquals("1", s);
+        s = new ExpandingExpressionParser("not important now", revert(Arrays.asList("1", "2", "3")), log).expandLd("..L2");
+        Assertions.assertEquals("1", s);
+        s = new ExpandingExpressionParser("not important now", revert(Arrays.asList("1", "2", "3")), log).expandLd("..L1");
+        Assertions.assertEquals("1,2", s);
+        s = new ExpandingExpressionParser("not important now", revert(Arrays.asList("1", "2", "3")), log).expandLd("..L0");
+        Assertions.assertEquals("1,2,3", s);
+    }
+
+    @org.junit.jupiter.api.Test
+    void expandLuTest() {
+        String s;
+        s = new ExpandingExpressionParser("not important now", revert(Arrays.asList("1", "2", "3")), log).expandLu("L5..");
+        Assertions.assertEquals("1,2,3", s);
+        s = new ExpandingExpressionParser("not important now", revert(Arrays.asList("1", "2", "3")), log).expandLu("L2..");
+        Assertions.assertEquals("1,2,3", s);
+        s = new ExpandingExpressionParser("not important now", revert(Arrays.asList("1", "2", "3")), log).expandLu("L1..");
+        Assertions.assertEquals("2,3", s);
+        s = new ExpandingExpressionParser("not important now", revert(Arrays.asList("1", "2", "3")), log).expandLu("L0..");
+        Assertions.assertEquals("3", s);
+    }
+
+    @org.junit.jupiter.api.Test
+    void expandLTest() {
+        String s;
+        s = new ExpandingExpressionParser("not important now", revert(Arrays.asList("1", "2", "3")), log).expandL("L5");
+        Assertions.assertEquals("1", s);
+        s = new ExpandingExpressionParser("not important now", revert(Arrays.asList("1", "2", "3")), log).expandL("L0");
+        Assertions.assertEquals("3", s);
+        s = new ExpandingExpressionParser("not important now", revert(Arrays.asList("1", "2", "3")), log).expandL("L1");
+        Assertions.assertEquals("2", s);
+        s = new ExpandingExpressionParser("not important now", revert(Arrays.asList("1", "2", "3")), log).expandL("L2");
+        Assertions.assertEquals("1", s);
+    }
+
+    @org.junit.jupiter.api.Test
+    void testEval() {
+        ExpandingExpressionParser comp;
+        comp = new ExpandingExpressionParser("max(L0..) == 3", revert(Arrays.asList("1", "2", "3")), log);
+        Assertions.assertTrue(comp.evaluate());
+        comp = new ExpandingExpressionParser("min(L0..L3)<= 1", revert(Arrays.asList("1", "2", "3")), log);
+        Assertions.assertTrue(comp.evaluate());
+        comp = new ExpandingExpressionParser("avg(..L1) <  L2/2+1", revert(Arrays.asList("1", "2", "3")), log);
+        Assertions.assertFalse(comp.evaluate());
+        comp = new ExpandingExpressionParser("sum(..L1) ==  L2 | false ", revert(Arrays.asList("1", "2", "3")), log);
+        Assertions.assertFalse(comp.evaluate());
+        comp = new ExpandingExpressionParser("sum(..L1) ==  L2 & false ", revert(Arrays.asList("1", "2", "3")), log);
+        Assertions.assertFalse(comp.evaluate());
+    }
+
+    static List<String> revert(List<String> l){
+        Collections.reverse(l);
+        return l;
+    }
+    @org.junit.jupiter.api.Test
+    /**
+     * The difference here is that we use real conditions
+     * and the revert, so L.. and ..L make now sense
+     * the revert is here (and in main imp in GenericChartPublisher),
+     * as the chart draw points as Lx...L2...L1..L0, not naturay,
+     * as the ExpandingExpressionParser expects)
+     */
+    void testRealLive() {
+        ExpandingExpressionParser comp;
+        comp = new ExpandingExpressionParser("L1 < L0", revert(Arrays.asList("628", "453", "545")), log);
+        Assertions.assertTrue(comp.evaluate());
+        comp = new ExpandingExpressionParser("avg(..L1) < L0", revert(Arrays.asList("5", "628", "453", "545")), log);
+        Assertions.assertTrue(comp.evaluate());
+        comp = new ExpandingExpressionParser("max(..L1) < L0 || 500 < L0",  revert(Arrays.asList("5", "628", "453", "545")), log);
+        Assertions.assertTrue(comp.evaluate());
+        comp = new ExpandingExpressionParser("500 < L0 && 600 > L0",  revert(Arrays.asList("5", "628", "453", "545")), log);
+        Assertions.assertTrue(comp.evaluate());
+        comp = new ExpandingExpressionParser("avg(..L1)*1.1 <  L0 | L1*1.3 <  L0 ", revert(Arrays.asList("60", "20", "45", "70")), log);
+        Assertions.assertTrue(comp.evaluate());
+    }
+
+    @Test
+    void testRealLiveCurl() {
+        ExpandingExpressionParser comp;
+        comp = new ExpandingExpressionParser("avg(..L{MN/2}) < avg(L{MN/2}..)", revert(Arrays.asList("2", "4", "6")), log);
+        Assertions.assertEquals("true", comp.solve());
+        comp = new ExpandingExpressionParser("L{1+L{1+0}}+L{-2+MN/0.8}", revert(Arrays.asList("22", "0", "66")), log);
+        Assertions.assertEquals("0.0", comp.solve());
+        comp = new ExpandingExpressionParser("L{{1}}", revert(Arrays.asList("2", "4", "6")), log);
+        Assertions.assertEquals("4", comp.solve());
+        comp = new ExpandingExpressionParser("L{{MN/2}}", revert(Arrays.asList("2", "4", "6")), log);
+        Assertions.assertEquals("4", comp.solve());
+    }
+
+    @Test
+    void testRealLiveWithBrackets() {
+        ExpandingExpressionParser comp;
+        comp = new ExpandingExpressionParser(" [[ avg(..L1)*1.1 <  L0 ] || [L1*1.3 <  L0 ]] || [ avgN(count(..L0)/4, ..L1)*1.1<L0 ] ", revert(Arrays.asList("60", "20", "45", "70")), log);
+        Assertions.assertTrue(comp.evaluate());
+
+    }
+}

--- a/src/test/java/parser/expanding/ExpandingExpressionParserWithReplacableLogicTest.java
+++ b/src/test/java/parser/expanding/ExpandingExpressionParserWithReplacableLogicTest.java
@@ -1,0 +1,74 @@
+package parser.expanding;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+
+import java.util.Arrays;
+
+import parser.ExpandingExpression;
+import parser.logical.LogicalExpressionFactoryTest;
+import parser.logical.PrintingExpressionLogger;
+
+
+import static parser.expanding.ExpandingExpressionParserTest.revert;
+
+class ExpandingExpressionParserWithReplacableLogicTest {
+
+    private static PrintingExpressionLogger log = new PrintingExpressionLogger();
+
+    @Test
+    void weirdRegressions() {
+        Assertions.assertTrue(new ExpandingExpressionParser("1+1 < ((2+0)*1) impl  false  eq  false", revert(Arrays.asList("1", "2", "3")), log).evaluate());
+        Assertions.assertFalse(new ExpandingExpressionParser("L0<L1 and L2<L3", revert(Arrays.asList("0", "1", "-1", "2")), log).evaluate());
+        Assertions.assertTrue(new ExpandingExpressionParser("L0<L1 and L2<L3", (Arrays.asList("0", "1", "-1", "2")), log).evaluate());
+    }
+
+    @Test
+    void replacableLogicalExpressionWithExpansion() {
+        //correct
+        Assertions.assertTrue(new ExpandingExpressionParser("L0<L1 and L2<L3", (Arrays.asList("0", "1", "-1", "2")), log).evaluate());
+        Assertions.assertFalse(new ExpandingExpressionParser("L0>L1 and L2>L3", (Arrays.asList("0", "1", "-1", "2")), log).evaluate());
+        //custom
+        Exception ex = null;
+        try {
+            Assertions.assertTrue(new ExpandingExpressionParser("L0>L1 and L2>L3", (Arrays.asList("0", "1", "-1", "2")), log, new LogicalExpressionFactoryTest.HogwartsMemberFactory()).evaluate());
+        } catch (Exception ex1) {
+            ex = ex1;
+        }
+        Assertions.assertTrue(new ExpandingExpressionParser("harry(L0..L2) and ron(L0..L2)", (Arrays.asList("0", "1", "-1", "2")), log, new LogicalExpressionFactoryTest.HogwartsMemberFactory()).evaluate());
+        Assertions.assertFalse(new ExpandingExpressionParser("tom(L0..L2) and ron(L0..L2)", (Arrays.asList("0", "1", "-1", "2")), log, new LogicalExpressionFactoryTest.HogwartsMemberFactory()).evaluate());
+        Assertions.assertNotNull(ex);
+        //not affected
+        Assertions.assertTrue(new ExpandingExpressionParser("true and true", (Arrays.asList("0", "1", "-1", "2")), log).evaluate());
+        Assertions.assertFalse(new ExpandingExpressionParser("false and true", (Arrays.asList("0", "1", "-1", "2")), log).evaluate());
+    }
+
+    @Test
+    void replacableLogicalExpressionBracketsWithExpansion() {
+        //correct
+        Assertions.assertEquals("true", new ExpandingExpression("[ L0<L1 and L2<L3 ] or [ L0<L1 and L2<L3 ] ", (Arrays.asList("0", "1", "-1", "2")), log).solve());
+        Assertions.assertEquals("false", new ExpandingExpression("[ L0>L1 and L2<2L3] or [L0>L1 and L2<L3]", (Arrays.asList("0", "1", "-1", "2")), log).solve());
+        String h1 = new ExpandingExpression("help", (Arrays.asList()), log).solve();
+        //custom
+        Exception ex = null;
+        try {
+            Assertions.assertEquals("true", new ExpandingExpression("[ L0>L1 and L2<2L3] or [L0>L1 and L2<L3]", (Arrays.asList("0", "1", "-1", "2")),
+                    log, new LogicalExpressionFactoryTest.HogwartsMemberFactory()).solve());
+        } catch (Exception ex1) {
+            ex = ex1;
+        }
+        Assertions.assertNotNull(ex);
+        String h2 = new ExpandingExpression("help", (Arrays.asList()),
+                log, new LogicalExpressionFactoryTest.HogwartsMemberFactory()).solve();
+        Assertions.assertEquals("true", new ExpandingExpression("[ harry(L3..L1) and ron(L3..L1)] or [ron(L3..L1) and tom(L3..L1)]", (Arrays.asList("0", "1", "-1", "2")),
+                log, new LogicalExpressionFactoryTest.HogwartsMemberFactory()).solve());
+        //not affected
+        Assertions.assertEquals("true", new ExpandingExpression("[ L0<L1 and L2<L3 ] or [ L0<L1 and L2<L3 ] ", (Arrays.asList("0", "1", "-1", "2")), log).solve());
+        Assertions.assertEquals("false", new ExpandingExpression("[ L0>L1 and L2<2L3] or [L0>L1 and L2<L3]", (Arrays.asList("0", "1", "-1", "2")), log).solve());
+        String h3 = new ExpandingExpression("help", (Arrays.asList()), log).solve();
+        Assertions.assertEquals(h3, h1);
+        Assertions.assertEquals(h3, h2); //the embedded factory have currenlty no eefect here
+    }
+
+}

--- a/src/test/java/parser/methods/DeclarationsTest.java
+++ b/src/test/java/parser/methods/DeclarationsTest.java
@@ -1,5 +1,6 @@
 package parser.methods;
 
+import logic.DRG_MODE;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import parser.MathExpression;
@@ -10,6 +11,11 @@ import java.math.BigDecimal;
 import java.util.List;
 
 class DeclarationsTest {
+    @Test
+    void fromJunk() {
+        MathExpression me = new MathExpression("x=10;sin(ln(x))");
+        Assertions.assertTrue("0.743980336957493".equals(me.solve()) || "0.7439803369574931".equals(me.solve()));//different on jdk11+ and 8-
+    }
 
     @Test
     void hardcodedFunctionCanBeOverwritten() {
@@ -58,6 +64,52 @@ class DeclarationsTest {
         Assertions.assertEquals("2.0", me.solve());
         Assertions.assertEquals(before, after);
         Assertions.assertEquals(before+1, during);
+    }
+
+    @Test
+    void changeDegRadGradViaProperty() {
+        try {
+            MathExpression me;
+            System.setProperty(DRG_MODE.DEG_MODE_VARIABLE, "DEG");
+            me = new MathExpression("sin(1)");
+            Assertions.assertEquals("0.01745240643728351", me.solve());
+            me = new MathExpression("sin(1)");
+            System.setProperty(DRG_MODE.DEG_MODE_VARIABLE, "RAD");
+            me = new MathExpression("sin(1)");
+            Assertions.assertEquals("0.8414709848078965", me.solve());
+            System.setProperty(DRG_MODE.DEG_MODE_VARIABLE, "GRAD");
+            me = new MathExpression("sin(1)");
+            Assertions.assertEquals("0.015707317311820675", me.solve());
+            System.setProperty(DRG_MODE.DEG_MODE_VARIABLE, "GRAD");
+            me = new MathExpression("sin(1)");
+            Assertions.assertEquals("0.015707317311820675", me.solve());
+            System.setProperty(DRG_MODE.DEG_MODE_VARIABLE, "RAD");
+            Assertions.assertEquals("0.015707317311820675", me.solve()); //do not affect existing instances
+            me = new MathExpression("sin(1)"); //is affecting all future nstance
+            Assertions.assertEquals("0.8414709848078965", me.solve());
+        } finally {
+            System.setProperty(DRG_MODE.DEG_MODE_VARIABLE, "RAD");
+        }
+   }
+
+    @Test
+    void changeDegRadGradViaSetter() {
+        try {
+            MathExpression meR = new MathExpression("sin(1)");
+            meR.setDRG(DRG_MODE.RAD);
+            Assertions.assertEquals("0.8414709848078965", meR.solve());
+            MathExpression meG = new MathExpression("sin(1)");
+            meG.setDRG(DRG_MODE.GRAD);
+            Assertions.assertEquals("0.015707317311820675", meG.solve());
+            MathExpression meD = new MathExpression("sin(1)");
+            meD.setDRG(DRG_MODE.DEG);
+            Assertions.assertEquals("0.01745240643728351", meD.solve());
+            Assertions.assertEquals("0.8414709848078965", meR.solve());
+            Assertions.assertEquals("0.015707317311820675", meG.solve());
+            Assertions.assertEquals("0.01745240643728351", meD.solve());
+        } finally {
+            System.setProperty(DRG_MODE.DEG_MODE_VARIABLE, "RAD");
+        }
     }
 
 }


### PR DESCRIPTION
ExpandingParser can work above unmodifiable array of numbers. It can work
also over slices of this array. Eg L1..L3 will work over slice form
original set ot second, third and fourt element. See help for details
Supported are slices Ln, ..Ln and Ln.. and special element of MN
containinf length of input array. Dynamic indexes can be counted by
L{expression} formula.
eg: VALUES_PNG='1 2 3' on 'avg(..L{L{MN/2}}) < avg(L{L{MN/2}}..)'
(however weird the nested dynamic indexes are). Verbose mode is showing
how expansion works.
Due to simple nature of slice creations, the ExpansionPArser is easy to
extend to any possible slices
