### PR TITLE
Added jdk21+25 to gh workgflows

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         # We test across all three to ensure backward compatibility
-        java-version: [ 8, 11, 17 ]
+        java-version: [ 8, 11, 17, 21, 25 ]
       fail-fast: false
 
     name: ${{ matrix.os }} - Java ${{ matrix.java-version }} - Maven


### PR DESCRIPTION
The actions must finish before merge. Although local build with 21 and 25 passes, it is never the same